### PR TITLE
chore: Add sessions/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ appinfo/signature.json
 # Internal documentation
 CLAUDE.md
 docs/archive/
+sessions/


### PR DESCRIPTION
## Summary

- Add `sessions/` to `.gitignore`
- Internal session protocols should not be in public repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)