### PR TITLE
Release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-03-16
+
+### Fixed
+- Vertragsdokument öffnet jetzt im Nextcloud Viewer als Overlay statt nur den Ordner anzuzeigen (#43)
+- Fallback bei fehlendem Viewer nutzt File-ID (`/f/{id}`) statt Parent-Ordner
+- "In Nextcloud öffnen" im Formular nutzt ebenfalls File-ID für zuverlässiges Öffnen
+- AI-Extraktionshinweise werden jetzt auf Deutsch angezeigt statt Englisch
+- Validierungsfehler (Enddatum) nutzt NcNoteCard statt schwer lesbarem eigenen Styling
+
+### Changed
+- Nextcloud Viewer wird auf der Verträge-Seite geladen (LoadViewer Event)
+
 ## [0.2.4] - 2026-03-12
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ Verwalten Sie Ihre Verträge zentral in Nextcloud:
 Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
     ]]></description>
 
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author homepage="https://github.com/cpcMomentum">Axel Deffner</author>

--- a/appinfo/signature.json
+++ b/appinfo/signature.json
@@ -1,9 +1,9 @@
 {
     "hashes": {
-        "CHANGELOG.md": "6eb497fd1d01ede655058a71dd4f4b6f2dd6ed9467e08b477126ae1667a1409d641535c2d05d9a4107911ac706f7650b1dedef6b3a42a24580a61c73c8bf94b4",
+        "CHANGELOG.md": "d8cd8deb4ad4e3dd19f22cfadcf4a8f1ec1a45737a71739dd37f2c4a388e93549dc59f853f2efbd4b6c6b4126a32370ee240206a2d8913e768f2170d17011134",
         "LICENSE": "3568a76677f3d55dbbc7fc33c4073b4714cc6f68d92cd842a9ca2b230e8bd2140e59c3fc3cce34be34ffed78d75ab6e9d991ba59bf7c4addde7fb96648d3375d",
         "README.md": "c63556c8007c335969e9ffd6836089907b332588f578a435cb67504ccdd2e0ddef71b5c60e733f1e8db2ded32c1caed39fff50deb497d4affc1ce6ad0d50b432",
-        "appinfo\/info.xml": "2a3a76842c18f9c29cad0fc847fc691dce9d0823e459903fffb4dd2a80d471210adda782d59ccdc0bcfc166daa8599d193814f61bf8509d463a9278cedaef619",
+        "appinfo\/info.xml": "53b80d5f73b7b3d21c00197c0db084a3f97589275dff55802fd721b5e7347321d764e70e8a881777e5faa508f70e396f3afd2ac2aef62b0eed4055c7c4c20299",
         "appinfo\/routes.php": "fff2483faf7004271c375e3de196ea8a250b9248d4a73913a9c82d2efd9ccab1144d37684d4a9ec47ad15069830d2e19f4dc50324287d07ac8311991ad2848b2",
         "css\/main.scss": "d663b32588adeec116bf4da24ac4cefee1e18bd72d0c18c51ae85ada04669e6d63e94b1c24a889960e5ed294d68952130db92ef3a6e9d4743fcf458519df8d0e",
         "img\/app.svg": "e86145b1095cd5bcb1007795f98c7c83bed8c72df63f29a1440a23913d2b5f018a62a74f207a8eef2435eca4e793631cde0917a6d37c5485bbebc6bf03a7c2a8",
@@ -12,7 +12,7 @@
         "js\/contractmanager-364451d6f66a4ac77677.js": "ee4731cc56f36b3405cef140b4fa731c2093437c47c7f4e1531fadc5420789db7af1c9abee8a28bc1274e0335284dd6fc49a973dab60037b687c076e73d7ca86",
         "js\/contractmanager-60eebdd401c5fb28589c.js": "c6ceddf2404144c123ee12623c65207e4c7710e0b41f42ce9c6bb8e5e022a04d85197cd754dfd3e3280f5b63f9163bdd90d32d6d5a8ee80a24b6d97aed6b818a",
         "js\/contractmanager-a0a859601bc3555e597d.js": "21d8de580ad9caf3f904ed9df082e6c9599e42eb45600ba31fb7f1ca5fb169424b9d5071446a7c69d0e12be496a91b7afd67637108e25958dc888bc424a9f72f",
-        "js\/contractmanager-main.js": "999f8bd9ea7d2eff7ef249cb11b590f404e166422e092ad3967a7c9647da9e215990ec2608bd008120c0c2c0b98637de489520936eabcd26a401f0c19162910e",
+        "js\/contractmanager-main.js": "fb80074746b7ac5ce9e4575011429faf7e486a222055f0f55d6f4ee63d42c6a62ad75d338133b33a62aed5cedbdb810865f6dfd5743cf2e55ed2da06415ed391",
         "l10n\/de.json": "88f7819883fd5e7959bf275ba240d773b965288c554b18b2cd9a539d130dfcf0d90470b576c676136b2b5d7ab230e93fd01ba5ee30d3a4ee39cdc126c8084991",
         "l10n\/en.json": "6d0575b34fd32018f88da3925b9b1a47d532a362fc8e531216fc112ee298ed25e52a7b87bac438d08e2bdac16a119ec1b1291fde2b7e74fbc5c759567c7e3675",
         "lib\/AppInfo\/Application.php": "7da45212daaa6ddbc995e7d695636b01afff487ee5e37a752fe329ef53f9ff34c182f5624d34ac3d1cbd51b0d9bd2e41d3d5bafe6b9498a6fab3403382404a1f",
@@ -21,7 +21,7 @@
         "lib\/Controller\/CategoryController.php": "8b4218bb8d6486a56fd2ae94ad5751dd6090b390eb8348441b419d0272b52a3066c98fd9a034cc2b5305152d48e528646741b59e9e1cbf0fa16dfbedcf84c0d1",
         "lib\/Controller\/ContractController.php": "54e4244f470330b688ad486e85c194a6cd345feb4cec35ed0238988b4ba484c0270f83d882f55b90912be35341bb6fc3d80f1ee1d50cf673e5a8911a8250b6b5",
         "lib\/Controller\/ExtractionController.php": "17e8fb578a8aaa80b428f4fb54682f78362679d432ac6b56e14b0ac12b8676999a87f8aa26b608acb5e9ed94efb8d70324947701d1dd006940aaec7269f588c6",
-        "lib\/Controller\/PageController.php": "261dbdc9e7beca45fa5a9f7ba9e528e91577b18af02e67cfadb206e87bc4cc812569ceaa4bfd11b4d2e4eae7b45632059135f04e2665bec2ff276cae03453f4c",
+        "lib\/Controller\/PageController.php": "2863ef6abe4bc0d6de645115b8ecfc4c4754a9b34412e8b484d024bad12ca6ac6033ad8c5bd948496f05a1127951847e139b963a83579c2fcb2114aadc79b160",
         "lib\/Controller\/SettingsController.php": "32b769199767445bcc34fd0dfde59d55ae2e65889c6ec15cec71580a8828795553b668eb47e67bdd9d3debe6bf3ec6cb6dbecddefa5efed92d476b6ba6ae4bd6",
         "lib\/Db\/Category.php": "71632a23ac01f2f5a086cc0c3730a7da650c99be9e7ca5beb50da05b5b5011c18988ab184fdd9006caa58f0c3e64be19322aaeda53b128356d8c2d962569667d",
         "lib\/Db\/CategoryMapper.php": "464f43e132f8f578ac7e0b9633b916576c9b6e47f6397765c99706d0f65448421561334597b291f517ccc94cb8c1781a025dea45e60e292ef1febf01ce241fff",
@@ -34,7 +34,7 @@
         "lib\/Migration\/Version010003Date20260118160000.php": "778758dd4f3dc788fe036976e9452249993d30accae540df2580e904ac8e8c9467c2b74211fcef19bedd610e9d12dc9e0520cc1a43a9bcb9e5d5b8ed8e0f20ce",
         "lib\/Migration\/Version010004Date20260121000000.php": "8e114ab573c573f460763677378e6b5197b0f0420970629707782af8408b49f218a785e1d8f158b8d03d18d1f01ba94d552374d63313df92169acf6d8f7d4cc4",
         "lib\/Migration\/Version010005Date20260308000000.php": "24646b13a63a4291352c7e5b5091ef8d1bbeace64c2934bc9d8597416eb432807ad3dccca1dbe59c34d8cfa6ae8aa3ece2b9c00aa431ba2be4875b0e36b8676e",
-        "lib\/Service\/AiExtractionService.php": "5f1af1baf95dc77f6776a32a34886b07598094439f933eaf6f491e0ab3914f92226c7c5e87752e9a0248fe33ae51d9bb4f90594d277744e93947d5dbc57395bd",
+        "lib\/Service\/AiExtractionService.php": "8aebc0a0ab6aef7d5f1d79470e2ce2e0100fcfbf0903c0727cfe32fbc6729d569dd4b7776dc0369a2e1f97d2dc13c22d119f9fd0b48fdd9ba5668630d3527347",
         "lib\/Service\/CategoryService.php": "b42d297806de69fcb7b6e7bf2362b24eb727ed096333457e454bee35862d740b5494c5aade2b4f793594ad08318d64cc628112c6c4aefdecd809424b39612450",
         "lib\/Service\/ContractService.php": "38875d32e4c1190b611585477cb61f6410e9ccadd69760a119e4d639e80cdb10ad98661ac1e51502e316614595daff4be51e3499dfe43e99e5673f3cc189413b",
         "lib\/Service\/EmailService.php": "ed91a49a8dabadb3ee39b7fe68ea0dc2304252e571daa1a1e24f9ca791b964fad49a95b28b98a074c0ea5c3650e7b879d8dbd5bb8531616f358e3aef0af5331e",
@@ -48,6 +48,6 @@
         "lib\/Service\/ValidationException.php": "77faf5ef3fd2d59ed6d4083cc6ce302c4e7da5727a589a354eaeb1bed93da9595176995d003ba4db62a63c626fe40605a9c0af5125f04b6626908e4ea462aebc",
         "templates\/main.php": "7ea4f5b4de5a202525aa3d751e05313e239df4413902bda3b4866f2cd2622bd6ae267fe7ac474819460a72558ea9045cb44af2bc317108820553eeb8fd6dea75"
     },
-    "signature": "G03x1pLKtpmSIUMcYp54tRQhQunOSqy6XzSrEo7c\/VjVOV9Q8t\/3nxURwYAGMX3vT0dLTJA8g6U36wbKQngYh+E6wU1uxk2hhjb786w0JrGlAQixYpbbPPCigx9zTcz+npi\/4EgkqyIvnuJ9C1+a15XHBuzUVXrRPjZdqzZ6dmcP7DxJHg8KboP6owuG1CkINUNJF17MGDsKe71CvedXIO3va1MjQB213udO\/zd\/Hp4GaTsUzPUq\/UZDpORDLkmqtOvCeA9tcXOMdiX92UNILGaAQb+IZ5IVq835g+basnyWTBrpJRXh3sWnWtIm4r29z6MAm6Y0Xs4\/E1cd5hJhvw==",
+    "signature": "IbLRbzM0IOi6fHO\/Mgjvyuo+TLbzR\/\/f5xgheRIxDKhfDWJDoGUd7hcRcpj04Ivosl\/0\/NQT2Fl8dF377vIsEtgepKvrMDERlayN6rEvcl+LOLbRNutku5jyPZXo3HP+o0XxZoGox\/dKWNT1qJErStAn4EHa8C5iKU3Ai8fkSzG\/P7IAJn8hZCsIVFcn7BAzkwllJ0hWbtaeVz3ZfBCcf7nRHE9nKnqoLETt3FnH\/HbdSRyBhpPYjC+1asHATofPEYLekjKeikuPIv3dZzlNwj3224JueU9\/17CwNfnJehvZgXQOtCnB+wrL9ekoeVk6Kj5JaUprPhk+uFo6VEpK5g==",
     "certificate": "-----BEGIN CERTIFICATE-----\r\nMIIDCjCCAfICAhLsMA0GCSqGSIb3DQEBCwUAMHsxCzAJBgNVBAYTAkRFMRswGQYD\r\nVQQIDBJCYWRlbi1XdWVydHRlbWJlcmcxFzAVBgNVBAoMDk5leHRjbG91ZCBHbWJI\r\nMTYwNAYDVQQDDC1OZXh0Y2xvdWQgQ29kZSBTaWduaW5nIEludGVybWVkaWF0ZSBB\r\ndXRob3JpdHkwHhcNMjYwMjAyMTU0MTQ4WhcNMzYwNTEwMTU0MTQ4WjAaMRgwFgYD\r\nVQQDDA9jb250cmFjdG1hbmFnZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\r\nAoIBAQC5R5Qp4Wm5Q2dDNSyN33MAIianNamIQCzLP9TqKbvrHUvhIb5XojZizo6H\r\n\/3jZTpRau83rYewLsJiEDgyuKdLiFYiuas5bdU6lie\/X2V21BeowwqlOGoVaiXwE\r\nvDmarjfhHAMIbW\/H8IyT1PEAvSLZLl8vofGDibsovGacRfBlj\/WhTQSVoFyc1N32\r\nivUM\/rta10BLN1JurgXjN6s33uqW19bTms+y9zO3C1Wpq\/KhwgVNIcoRdio4uA0e\r\nSAnQQHE1HUieBDydwP52fFnlqf4l1OjP\/WLeNrwFNWdCBqZIEZsynASFHae\/cyOs\r\nqebHseLaDRkySMmHLv2hsH\/\/dm6rAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAD08\r\nvS9I3TjEfSfcF45IdanGUsrSMm7rCdQpdVaY7xyB8w6BymWgv9q0I4rATyCYgNIU\r\nN8TNGNNXHutvlOJ8ACdTxDs0bitSM0VY0lNqCVInRIT3W8UfoOmvpVG6Xc5eEi1Z\r\nO1JLVd\/lH6n86cHnkcMeSH265JwdGfKFF86g94YfDJ+uU4OLwaAnmeJaWTCHn3Nm\r\nFXWrSzvpPU7y47yCAJok+1Na0pXx5Y6BxId95ZBSBKPXmFpANvU58v52Ed+6npl5\r\nc6wfDUcb1088N4NBP8j76ci5BB358vTSwjAV5moyFUZO63vPRRcfP1Rq03LUfWyi\r\ndg1AcSTaDHL7vhQm19M=\r\n-----END CERTIFICATE-----"
 }


### PR DESCRIPTION
## [0.2.5] - 2026-03-16

### Fixed
- Vertragsdokument öffnet jetzt im Nextcloud Viewer als Overlay statt nur den Ordner anzuzeigen (#43)
- Fallback bei fehlendem Viewer nutzt File-ID (`/f/{id}`) statt Parent-Ordner
- "In Nextcloud öffnen" im Formular nutzt ebenfalls File-ID für zuverlässiges Öffnen
- AI-Extraktionshinweise werden jetzt auf Deutsch angezeigt statt Englisch
- Validierungsfehler (Enddatum) nutzt NcNoteCard statt schwer lesbarem eigenen Styling

### Changed
- Nextcloud Viewer wird auf der Verträge-Seite geladen (LoadViewer Event)