### PR TITLE
feat: Automatische Statusaenderung fuer abgelaufene Vertraege (#53)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -46,6 +46,7 @@ Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
     <background-jobs>
         <job>OCA\ContractManager\BackgroundJob\ReminderJob</job>
         <job>OCA\ContractManager\BackgroundJob\TrashCleanupJob</job>
+        <job>OCA\ContractManager\BackgroundJob\StatusUpdateJob</job>
     </background-jobs>
 
     <navigations>

--- a/lib/BackgroundJob/StatusUpdateJob.php
+++ b/lib/BackgroundJob/StatusUpdateJob.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\BackgroundJob;
+
+use DateTime;
+use OCA\ContractManager\AppInfo\Application;
+use OCA\ContractManager\Db\ContractMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Background job that automatically sets expired fixed contracts to "ended"
+ * Runs once per day
+ */
+class StatusUpdateJob extends TimedJob {
+
+	public function __construct(
+		ITimeFactory $time,
+		private ContractMapper $contractMapper,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($time);
+
+		// Run once per day (24 * 60 * 60 = 86400 seconds)
+		$this->setInterval(86400);
+	}
+
+	protected function run($argument): void {
+		$this->logger->info('Starting expired contract status check', [
+			'app' => Application::APP_ID,
+		]);
+
+		try {
+			$expiredContracts = $this->contractMapper->findExpiredActiveFixed();
+			$updatedCount = 0;
+
+			foreach ($expiredContracts as $contract) {
+				$contract->setStatus('ended');
+				$contract->setUpdatedAt(new DateTime());
+				$this->contractMapper->update($contract);
+				$updatedCount++;
+
+				$this->logger->info('Contract status set to ended: ' . $contract->getName(), [
+					'app' => Application::APP_ID,
+					'contractId' => $contract->getId(),
+					'endDate' => $contract->getEndDate()?->format('Y-m-d'),
+				]);
+			}
+
+			$this->logger->info('Expired contract status check completed', [
+				'app' => Application::APP_ID,
+				'updatedCount' => $updatedCount,
+			]);
+		} catch (\Exception $e) {
+			$this->logger->error('Expired contract status check failed', [
+				'app' => Application::APP_ID,
+				'exception' => $e->getMessage(),
+			]);
+		}
+	}
+}

--- a/lib/Db/ContractMapper.php
+++ b/lib/Db/ContractMapper.php
@@ -231,6 +231,23 @@ class ContractMapper extends QBMapper {
     }
 
     /**
+     * Find active fixed contracts whose end date has passed
+     *
+     * @return Contract[]
+     */
+    public function findExpiredActiveFixed(): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('status', $qb->createNamedParameter(Contract::STATUS_ACTIVE)))
+            ->andWhere($qb->expr()->eq('contract_type', $qb->createNamedParameter('fixed')))
+            ->andWhere($qb->expr()->lt('end_date', $qb->createNamedParameter(new \DateTime(), IQueryBuilder::PARAM_DATE)))
+            ->andWhere($qb->expr()->isNull('deleted_at'));
+
+        return $this->findEntities($qb);
+    }
+
+    /**
      * Search contracts by name or vendor for a user
      *
      * @return Contract[]


### PR DESCRIPTION
## Summary
- Neuer Background-Job `StatusUpdateJob` der täglich läuft
- Setzt abgelaufene befristete Verträge automatisch von "Laufend" auf "Beendet"
- auto_renewal-Verträge sind nicht betroffen

## Geänderte/Neue Dateien
- `lib/BackgroundJob/StatusUpdateJob.php` (NEU) – Täglicher Job
- `lib/Db/ContractMapper.php` – Neue Methode `findExpiredActiveFixed()`
- `appinfo/info.xml` – Job-Registrierung

## Test Results
- Job manuell auf Docker ausgeführt
- ID 5 (fixed, Enddatum 2022): active → ended ✅
- ID 12 (auto_renewal, Enddatum 2014): bleibt active ✅
- ID 8 (fixed, Enddatum Zukunft): bleibt active ✅

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)