### PR TITLE
fix: RepairStep to clean up extra files from earlier releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-11
+
+### Fixed
+- Automatische Bereinigung von Extra-Dateien aus frueheren Releases via RepairStep
+
 ## [0.4.1] - 2026-04-11
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ Verwalten Sie Ihre Verträge zentral in Nextcloud:
 Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
     ]]></description>
 
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <licence>AGPL-3.0-or-later</licence>
 
     <author mail="axel.deffner@cpcmomentum.com" homepage="https://github.com/cpcMomentum">Axel Deffner</author>
@@ -48,6 +48,12 @@ Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
         <job>OCA\ContractManager\BackgroundJob\TrashCleanupJob</job>
         <job>OCA\ContractManager\BackgroundJob\StatusUpdateJob</job>
     </background-jobs>
+
+    <repair-steps>
+        <post-migration>
+            <step>OCA\ContractManager\Migration\CleanupExtraFiles</step>
+        </post-migration>
+    </repair-steps>
 
     <navigations>
         <navigation>

--- a/lib/Migration/CleanupExtraFiles.php
+++ b/lib/Migration/CleanupExtraFiles.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Migration;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Remove extra files that were accidentally included in earlier releases
+ * and cause integrity check failures.
+ */
+class CleanupExtraFiles implements IRepairStep {
+
+	public function getName(): string {
+		return 'Remove extra files from earlier releases';
+	}
+
+	public function run(IOutput $output): void {
+		$appPath = \OC_App::getAppPath('contractmanager');
+		if ($appPath === false) {
+			return;
+		}
+
+		$filesToRemove = [
+			$appPath . '/test-results/.last-run.json',
+		];
+
+		$dirsToRemove = [
+			$appPath . '/test-results',
+		];
+
+		foreach ($filesToRemove as $file) {
+			if (file_exists($file)) {
+				@unlink($file);
+				$output->info('Removed: ' . basename($file));
+			}
+		}
+
+		foreach ($dirsToRemove as $dir) {
+			if (is_dir($dir)) {
+				@rmdir($dir);
+				$output->info('Removed directory: ' . basename($dir));
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `CleanupExtraFiles` RepairStep that runs on update
- Automatically removes `test-results/` left from earlier tarballs
- Fixes integrity check failures for all users on update to v0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)