### PR TITLE
fix: add cancellationDeadline to sort-by whitelist

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -44,7 +44,7 @@ class SettingsService {
 	private const DEFAULT_REMINDER_DAYS_1 = 14;
 	private const DEFAULT_REMINDER_DAYS_2 = 3;
 
-	private const ALLOWED_SORT_BY = ['endDate', 'name', 'updatedAt', 'cost'];
+	private const ALLOWED_SORT_BY = ['endDate', 'name', 'updatedAt', 'cost', 'cancellationDeadline'];
 	private const ALLOWED_SORT_DIRECTION = ['asc', 'desc'];
 	private const ALLOWED_FILTER_KEYS = ['vendor', 'statuses', 'contractType'];
 	private const ALLOWED_STATUSES = ['active', 'cancelled', 'ended'];


### PR DESCRIPTION
## Summary
- `cancellationDeadline` fehlte in der Backend-Whitelist für erlaubte Sort-Felder
- Sortierung nach "Kündigen bis" wurde stillschweigend nicht gespeichert und sprang auf den Default zurück

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)