### PR TITLE
chore: auto-resolve js/ merge conflicts via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+js/** merge=ours


### PR DESCRIPTION
Adds `.gitattributes` so that `js/` conflicts during branch merges are automatically resolved in favor of the target branch (develop). No manual conflict resolution needed anymore.

The release skill rebuilds `js/` fresh anyway (Step 3.1: `rm -rf js/ && npm run build`), so the stale js/ between merges is harmless.