### PR TITLE
fix(reminders): send only final reminder when both windows active simultaneously

### DIFF
--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -45,8 +45,11 @@ class ReminderService {
 		$contracts = $this->contractMapper->findContractsNeedingReminder();
 
 		foreach ($contracts as $contract) {
+			// Pre-compute to avoid double DB query when both windows are active
+			$sendFinal = $this->shouldSendFinalReminder($contract);
+
 			// Check for first reminder — skip if final reminder is also due to avoid two emails on the same day
-			if ($this->shouldSendFirstReminder($contract) && !$this->shouldSendFinalReminder($contract)) {
+			if ($this->shouldSendFirstReminder($contract) && !$sendFinal) {
 				try {
 					$this->sendReminders($contract, 'first');
 					$this->markReminderSent($contract, 'first');
@@ -65,7 +68,7 @@ class ReminderService {
 			}
 
 			// Check for final reminder
-			if ($this->shouldSendFinalReminder($contract)) {
+			if ($sendFinal) {
 				try {
 					$this->sendReminders($contract, 'final');
 					$this->markReminderSent($contract, 'final');

--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -45,8 +45,8 @@ class ReminderService {
 		$contracts = $this->contractMapper->findContractsNeedingReminder();
 
 		foreach ($contracts as $contract) {
-			// Check for first reminder
-			if ($this->shouldSendFirstReminder($contract)) {
+			// Check for first reminder — skip if final reminder is also due to avoid two emails on the same day
+			if ($this->shouldSendFirstReminder($contract) && !$this->shouldSendFinalReminder($contract)) {
 				try {
 					$this->sendReminders($contract, 'first');
 					$this->markReminderSent($contract, 'first');

--- a/tests/Unit/Service/ReminderServiceTest.php
+++ b/tests/Unit/Service/ReminderServiceTest.php
@@ -273,7 +273,8 @@ class ReminderServiceTest extends TestCase {
 
 	public function testCalculateCancellationDeadlineAutoRenewal(): void {
 		// End date in the past, auto_renewal with 12 months, cancellation 3 months
-		$endDate = new DateTime('2022-08-17');
+		// Use dynamic past date so the test stays date-independent
+		$endDate = new DateTime('-2 years');
 		$contract = $this->createContract($endDate, '3 months', 'auto_renewal', '12 months');
 
 		$result = $this->service->calculateCancellationDeadline($contract);
@@ -426,6 +427,47 @@ class ReminderServiceTest extends TestCase {
 			->willReturn(true);
 
 		$this->service->shouldSendFirstReminder($contract);
+	}
+
+	// ========================================
+	// checkAndSendReminders Tests
+	// ========================================
+
+	/**
+	 * Regression: Issue #111 — Doppelte Mail wenn beide Reminder-Fenster gleichzeitig aktiv
+	 *
+	 * Wenn ein User Benachrichtigungen aktiviert und der Vertrag bereits im Final-Fenster
+	 * liegt, darf nur eine Mail rausgehen (final), nicht zwei (first + final).
+	 */
+	public function testCheckAndSendRemindersOnlySendsFinalWhenBothWindowsActive(): void {
+		// Deadline in 2 Tagen → liegt im first-Fenster (14 Tage) UND final-Fenster (3 Tage)
+		$deadline = new DateTime('+2 days');
+		// auto_renewal mit cancellationPeriod = 0 days → deadline = endDate
+		$contract = new \OCA\ContractManager\Db\Contract();
+		$contract->setId(42);
+		$contract->setName('Doppelmail-Test');
+		$contract->setVendor('Test');
+		$contract->setCreatedBy('testuser');
+		$contract->setStatus(\OCA\ContractManager\Db\Contract::STATUS_ACTIVE);
+		$contract->setReminderEnabled(1);
+		$contract->setArchived(0);
+		$contract->setEndDate($deadline);
+		$contract->setCancellationPeriod('');
+		$contract->setContractType('fixed');
+
+		$this->contractMapper->method('findContractsNeedingReminder')->willReturn([$contract]);
+		$this->settingsService->method('getReminderDays1')->willReturn(14);
+		$this->settingsService->method('getReminderDays2')->willReturn(3);
+		$this->settingsService->method('getUserEmailReminder')->willReturn(true);
+		$this->reminderSentMapper->method('hasBeenSent')->willReturn(false);
+		$this->reminderSentMapper->method('insert')->willReturn(new \OCA\ContractManager\Db\ReminderSent());
+		$this->talkService->method('isTalkAvailable')->willReturn(false);
+
+		// KERN-ASSERTION: emailService darf genau 1x aufgerufen werden, nicht 2x
+		$this->emailService->expects($this->exactly(1))
+			->method('sendReminder');
+
+		$this->service->checkAndSendReminders();
 	}
 
 	// ========================================


### PR DESCRIPTION
## Problem

When users enable notifications and the contract deadline is already within both the first (e.g. 14 days) and final (e.g. 3 days) reminder window, both reminders fire in the same cron run — resulting in two emails on the same day.

Reported by @myssv in #111.

## Root Cause

`checkAndSendReminders()` evaluates both `shouldSendFirstReminder()` and `shouldSendFinalReminder()` independently. If both windows are simultaneously active (e.g. deadline in 2 days, first window = 14d, final window = 3d), both return `true` and two emails are sent.

## Fix

Skip the first reminder if the final reminder is also due in the same run:

```php
// Before
if ($this->shouldSendFirstReminder($contract)) { ... }

// After
if ($this->shouldSendFirstReminder($contract) && !$this->shouldSendFinalReminder($contract)) { ... }
```

## Tests

- Added regression test `testCheckAndSendRemindersOnlySendsFinalWhenBothWindowsActive` — confirmed it **fails** before the fix and **passes** after
- Fixed `testCalculateCancellationDeadlineAutoRenewal` to use a dynamic past date (the hardcoded `2022-08-17` caused the cancellation deadline to flip to the next renewal period as of 2026-05-18)

Fixes #111