### PR TITLE
fix(reminders): respect per-contract reminderDays override in final reminder

### DIFF
--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -291,8 +291,17 @@ class ReminderService {
 			return false;
 		}
 
-		// Final reminder uses the second setting (default: 3 days)
 		$reminderDays = $this->settingsService->getReminderDays2();
+
+		// If the contract has a custom first-reminder override that fires at the same time
+		// or later than the final reminder window, suppress the final reminder.
+		// Example: contract override = 2 days, global days2 = 3 days → final would fire
+		// before (or at) the first reminder, making it confusing and redundant.
+		$contractOverride = $contract->getReminderDays();
+		if ($contractOverride !== null && $contractOverride <= $reminderDays) {
+			return false;
+		}
+
 		$now = new DateTime();
 		$reminderDate = clone $deadline;
 		$reminderDate->modify("-{$reminderDays} days");

--- a/tests/Unit/Service/ReminderServiceTest.php
+++ b/tests/Unit/Service/ReminderServiceTest.php
@@ -227,6 +227,74 @@ class ReminderServiceTest extends TestCase {
 	}
 
 	// ========================================
+	// shouldSendFinalReminder — contract override Tests
+	// ========================================
+
+	/**
+	 * Regression: Issue #116 — Final reminder ignoriert contract-spezifisches reminderDays-Override
+	 *
+	 * Wenn ein Vertrag ein Override hat das <= days2 ist, würde die finale Erinnerung
+	 * vor (oder gleichzeitig mit) der ersten feuern — das ist redundant und verwirrend.
+	 */
+	public function testShouldSendFinalReminderReturnsFalseWhenOverrideLeqDays2(): void {
+		// Contract override = 2 Tage, global days2 = 3 → final würde vor first feuern → unterdrücken
+		$endDate = new DateTime('+2 days');
+		$contract = $this->createContract($endDate, '', 'fixed');
+		$contract->setId(1);
+		$contract->setReminderDays(2);
+
+		$this->settingsService->method('getReminderDays2')->willReturn(3);
+
+		$result = $this->service->shouldSendFinalReminder($contract);
+
+		$this->assertFalse($result);
+	}
+
+	public function testShouldSendFinalReminderReturnsFalseWhenOverrideEqualsDays2(): void {
+		// Override exakt gleich days2 → ebenfalls unterdrücken
+		$endDate = new DateTime('+3 days');
+		$contract = $this->createContract($endDate, '', 'fixed');
+		$contract->setId(1);
+		$contract->setReminderDays(3);
+
+		$this->settingsService->method('getReminderDays2')->willReturn(3);
+
+		$result = $this->service->shouldSendFinalReminder($contract);
+
+		$this->assertFalse($result);
+	}
+
+	public function testShouldSendFinalReminderFiresNormallyWhenOverrideGreaterThanDays2(): void {
+		// Override = 30 Tage, global days2 = 3 → final feuert ganz normal 3 Tage vorher
+		$endDate = new DateTime('+2 days');
+		$contract = $this->createContract($endDate, '', 'fixed');
+		$contract->setId(1);
+		$contract->setReminderDays(30);
+
+		$this->settingsService->method('getReminderDays2')->willReturn(3);
+		$this->reminderSentMapper->method('hasBeenSent')->willReturn(false);
+
+		$result = $this->service->shouldSendFinalReminder($contract);
+
+		$this->assertTrue($result);
+	}
+
+	public function testShouldSendFinalReminderFiresNormallyWithoutOverride(): void {
+		// Kein Override → globaler days2 gilt unverändert
+		$endDate = new DateTime('+2 days');
+		$contract = $this->createContract($endDate, '', 'fixed');
+		$contract->setId(1);
+		// reminderDays bleibt null (kein Override)
+
+		$this->settingsService->method('getReminderDays2')->willReturn(3);
+		$this->reminderSentMapper->method('hasBeenSent')->willReturn(false);
+
+		$result = $this->service->shouldSendFinalReminder($contract);
+
+		$this->assertTrue($result);
+	}
+
+	// ========================================
 	// getEffectiveEndDate Tests
 	// ========================================
 
@@ -273,7 +341,8 @@ class ReminderServiceTest extends TestCase {
 
 	public function testCalculateCancellationDeadlineAutoRenewal(): void {
 		// End date in the past, auto_renewal with 12 months, cancellation 3 months
-		$endDate = new DateTime('2022-08-17');
+		// Use dynamic past date so the test stays date-independent
+		$endDate = new DateTime('-2 years');
 		$contract = $this->createContract($endDate, '3 months', 'auto_renewal', '12 months');
 
 		$result = $this->service->calculateCancellationDeadline($contract);


### PR DESCRIPTION
## Summary

- `shouldSendFinalReminder()` now respects the per-contract `reminderDays` override
- If the override is `<= reminderDays2` (global), the final reminder is suppressed — the first reminder (at the override timing) becomes the single notification
- Added 4 regression tests covering all override scenarios
- Side fix: `testCalculateCancellationDeadlineAutoRenewal` uses a dynamic past date now (the hardcoded `2022-08-17` had become stale)

## Background

Discovered by the Claude Bot during review of PR #115. The override field on contracts only affected the first reminder, not the final — inconsistent and surprising for users who set a per-contract value expecting it to apply to the whole reminder cycle.

## Test plan

- [x] Unit tests pass (32/32 ReminderServiceTest)
- [ ] Manual test: set a contract with `reminderDays = 2`, global `reminderDays2 = 3` → only ONE reminder fires at 2 days before deadline
- [ ] Manual test: set a contract with `reminderDays = 30`, global `reminderDays2 = 3` → first fires at 30 days, final still fires at 3 days

Closes #116