### PR TITLE
feat(notes): make URLs in contract notes clickable in read-only view

### DIFF
--- a/src/components/ContractForm.vue
+++ b/src/components/ContractForm.vue
@@ -351,7 +351,14 @@
 					<h3>{{ t('contractmanager', 'Notizen') }}</h3>
 
 					<div class="form-row">
-						<NcTextArea :value.sync="form.notes"
+						<!-- eslint-disable vue/no-v-html -- linkifyText escapes HTML before linkifying -->
+						<div v-if="readOnly && form.notes"
+							class="notes-readonly"
+							:aria-label="t('contractmanager', 'Zusätzliche Notizen')"
+							v-html="linkifiedNotes" />
+						<!-- eslint-enable vue/no-v-html -->
+						<NcTextArea v-else
+							:value.sync="form.notes"
 							:label="t('contractmanager', 'Zusätzliche Notizen')"
 							:placeholder="t('contractmanager', 'Zusätzliche Notizen...')"
 							:maxlength="5000"
@@ -423,6 +430,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { formatDate, formatDateForInput } from '../utils/dateUtils.js'
 import { parsePeriod, calculateCancellationDeadline } from '../utils/periodUtils.js'
 import { isUrl, isInternalUrl, getDisplayName } from '../utils/documentUtils.js'
+import { linkifyText } from '../utils/linkify.js'
 import ExtractionService from '../services/ExtractionService.js'
 import SettingsService from '../services/SettingsService.js'
 import { showSuccess, showError, showWarning } from '@nextcloud/dialogs'
@@ -490,6 +498,9 @@ export default {
 		},
 		documentDisplayName() {
 			return getDisplayName(this.form.mainDocument)
+		},
+		linkifiedNotes() {
+			return linkifyText(this.form.notes)
 		},
 		isExternalDocument() {
 			return isUrl(this.form.mainDocument) && !isInternalUrl(this.form.mainDocument)
@@ -1216,6 +1227,28 @@ export default {
 	border-radius: 4px;
 	font-size: 13px;
 	color: var(--color-warning-text, #856404);
+}
+
+.notes-readonly {
+	width: 100%;
+	min-height: 80px;
+	padding: 8px 12px;
+	background: var(--color-background-hover);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	font-size: 14px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+
+	a {
+		color: var(--color-primary-element);
+		text-decoration: underline;
+
+		&:hover, &:focus {
+			text-decoration: none;
+		}
+	}
 }
 
 .selected-path {

--- a/src/utils/linkify.js
+++ b/src/utils/linkify.js
@@ -1,0 +1,48 @@
+/**
+ * Linkify utility — converts plain text to HTML with clickable URLs.
+ * XSS-safe: escapes all HTML entities before applying link replacement.
+ */
+
+const HTML_ESCAPE_MAP = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	'\'': '&#39;',
+}
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ *
+ * @param {string} text - raw input
+ * @returns {string} HTML-escaped text
+ */
+function escapeHtml(text) {
+	return text.replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch])
+}
+
+/**
+ * Convert plain text to HTML with clickable links.
+ *
+ * Detects http(s) URLs and wraps them in safe anchor tags.
+ * Input is fully HTML-escaped first, so the result is safe to use with v-html.
+ *
+ * @param {string|null|undefined} text - plain text input (notes content)
+ * @returns {string} HTML string with linkified URLs and preserved newlines
+ */
+export function linkifyText(text) {
+	if (!text) return ''
+
+	const escaped = escapeHtml(String(text))
+
+	// Match http:// and https:// URLs, stopping at whitespace or common trailing punctuation.
+	// Trailing punctuation (.,;:!?) is preserved as text rather than included in the link.
+	const urlRegex = /\bhttps?:\/\/[^\s<]+[^\s<.,;:!?)\]}'"]/g
+
+	const linked = escaped.replace(urlRegex, url =>
+		`<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`,
+	)
+
+	// Preserve newlines in HTML output
+	return linked.replace(/\n/g, '<br>')
+}


### PR DESCRIPTION
## Summary

- Adds `src/utils/linkify.js` — small utility that HTML-escapes input then wraps detected http/https URLs in `<a target="_blank" rel="noopener noreferrer">`
- In `ContractForm.vue` notes section: when `readOnly && form.notes`, render the linkified content via `v-html`; edit mode keeps the plain `NcTextArea` (no rich-text editor introduced)
- Adds matching `.notes-readonly` styles using NC CSS variables

## Acceptance criteria (Issue #108)

- [x] URLs in notes are clickable in the read-only view
- [x] Links open in a new tab (`target="_blank"`)
- [x] Input remains a plain-text textarea (no rich-text editor)
- [x] XSS-safe — input is HTML-escaped before linkification

## Test plan

Verified in the browser console with a sample note containing two URLs and an XSS attempt (`<script>alert(1)</script>`):

| Check | Result |
|-------|--------|
| Two URLs detected as `<a>` | ✅ 2 links |
| `target="_blank"` on each link | ✅ |
| `rel="noopener noreferrer"` on each link | ✅ |
| `<script>` rendered as escaped text, not executed | ✅ |
| Newlines preserved as `<br>` | ✅ 2 newlines |

Manual UI verification of the readOnly mode requires a non-admin/non-creator user viewing a public contract — the visual readonly state is identical to the verified logic.

Closes #108