### PR TITLE
fix(security): validate AI API URL scheme and host (#123)

### DIFF
--- a/lib/Service/AiExtractionService.php
+++ b/lib/Service/AiExtractionService.php
@@ -128,7 +128,7 @@ PROMPT;
 	private function extractWithClaude(string $text, bool $isScanned, string $rawContent): array {
 		$apiKey = $this->settingsService->getAiApiKey();
 		$model = $this->settingsService->getAiModel();
-		$apiUrl = $this->settingsService->getAiApiUrl();
+		$apiUrl = rtrim($this->settingsService->getAiApiUrl(), '/');
 
 		if ($isScanned && $rawContent !== '') {
 			// Vision mode: send PDF as base64

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -382,7 +382,38 @@ class SettingsService {
 	}
 
 	public function setAiApiUrl(string $url): void {
+		if ($url !== '' && !$this->isValidAiApiUrl($url)) {
+			return;
+		}
 		$this->config->setAppValue(Application::APP_ID, self::KEY_AI_API_URL, $url);
+	}
+
+	/**
+	 * Validate AI API URL: must be https, or http only for local hosts (Ollama).
+	 * Used as defense-in-depth — only admins reach this path in normal flow.
+	 */
+	public function isValidAiApiUrl(string $url): bool {
+		if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+			return false;
+		}
+		$scheme = strtolower((string)parse_url($url, PHP_URL_SCHEME));
+		if ($scheme === 'https') {
+			return true;
+		}
+		if ($scheme !== 'http') {
+			return false;
+		}
+		$host = strtolower((string)parse_url($url, PHP_URL_HOST));
+		if ($host === '') {
+			return false;
+		}
+		if ($host === 'localhost' || $host === '127.0.0.1' || $host === '[::1]') {
+			return true;
+		}
+		if (str_ends_with($host, '.local') || str_ends_with($host, '.localhost')) {
+			return true;
+		}
+		return false;
 	}
 
 	public function getAiModel(): string {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -407,7 +407,7 @@ class SettingsService {
 		if ($host === '') {
 			return false;
 		}
-		if ($host === 'localhost' || $host === '127.0.0.1' || $host === '[::1]') {
+		if ($host === 'localhost' || $host === '127.0.0.1' || $host === '::1') {
 			return true;
 		}
 		if (str_ends_with($host, '.local') || str_ends_with($host, '.localhost')) {

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -195,4 +195,85 @@ class SettingsServiceTest extends TestCase {
 
 		$this->service->setUserEmailReminder('testuser', false);
 	}
+
+	// ========================================
+	// AI API URL Validation Tests (Issue #123)
+	// ========================================
+
+	public function testIsValidAiApiUrlAcceptsHttps(): void {
+		$this->assertTrue($this->service->isValidAiApiUrl('https://api.anthropic.com'));
+		$this->assertTrue($this->service->isValidAiApiUrl('https://api.openai.com/v1'));
+		$this->assertTrue($this->service->isValidAiApiUrl('https://example.com:8443/path'));
+	}
+
+	public function testIsValidAiApiUrlAcceptsHttpForLocalHosts(): void {
+		$this->assertTrue($this->service->isValidAiApiUrl('http://localhost:11434'));
+		$this->assertTrue($this->service->isValidAiApiUrl('http://127.0.0.1:11434'));
+		$this->assertTrue($this->service->isValidAiApiUrl('http://[::1]:11434'));
+		$this->assertTrue($this->service->isValidAiApiUrl('http://ollama.local'));
+		$this->assertTrue($this->service->isValidAiApiUrl('http://server.localhost'));
+	}
+
+	public function testIsValidAiApiUrlRejectsHttpForRemoteHosts(): void {
+		$this->assertFalse($this->service->isValidAiApiUrl('http://api.openai.com'));
+		$this->assertFalse($this->service->isValidAiApiUrl('http://example.com'));
+	}
+
+	public function testIsValidAiApiUrlRejectsOtherSchemes(): void {
+		$this->assertFalse($this->service->isValidAiApiUrl('file:///etc/passwd'));
+		$this->assertFalse($this->service->isValidAiApiUrl('ftp://example.com'));
+		$this->assertFalse($this->service->isValidAiApiUrl('javascript:alert(1)'));
+		$this->assertFalse($this->service->isValidAiApiUrl('gopher://example.com'));
+	}
+
+	public function testIsValidAiApiUrlRejectsMalformed(): void {
+		$this->assertFalse($this->service->isValidAiApiUrl('not a url'));
+		$this->assertFalse($this->service->isValidAiApiUrl('http://'));
+		$this->assertFalse($this->service->isValidAiApiUrl(''));
+	}
+
+	public function testSetAiApiUrlSavesValidUrl(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'ai_api_url', 'https://api.anthropic.com');
+
+		$this->service->setAiApiUrl('https://api.anthropic.com');
+	}
+
+	public function testSetAiApiUrlSavesLocalHttp(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'ai_api_url', 'http://localhost:11434');
+
+		$this->service->setAiApiUrl('http://localhost:11434');
+	}
+
+	public function testSetAiApiUrlClearsWithEmpty(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'ai_api_url', '');
+
+		$this->service->setAiApiUrl('');
+	}
+
+	public function testSetAiApiUrlIgnoresInvalidScheme(): void {
+		$this->config->expects($this->never())
+			->method('setAppValue');
+
+		$this->service->setAiApiUrl('file:///etc/passwd');
+	}
+
+	public function testSetAiApiUrlIgnoresHttpForRemote(): void {
+		$this->config->expects($this->never())
+			->method('setAppValue');
+
+		$this->service->setAiApiUrl('http://api.openai.com');
+	}
+
+	public function testSetAiApiUrlIgnoresMalformed(): void {
+		$this->config->expects($this->never())
+			->method('setAppValue');
+
+		$this->service->setAiApiUrl('not a url');
+	}
 }


### PR DESCRIPTION
## Summary

- `SettingsService::setAiApiUrl()` validiert jetzt Schema und Host
- `https://` immer erlaubt, `http://` nur für lokale Hosts (localhost, 127.0.0.1, [::1], *.local, *.localhost — Ollama-Use-Case)
- Ungültige URLs werden silent abgelehnt (kein Save)
- 11 neue Unit-Tests in `SettingsServiceTest`

## Test plan

- [x] Vollständige PHPUnit-Suite läuft grün (88 Tests, 157 Assertions)
- [x] PHP lint OK
- [ ] Manuell im Admin-Settings: HTTPS-URL akzeptiert, http://api.openai.com abgelehnt

Fixes #123