### PR TITLE
fix(security): reduce PII in log output (#125)

### DIFF
--- a/lib/Service/EmailService.php
+++ b/lib/Service/EmailService.php
@@ -98,9 +98,9 @@ class EmailService {
 
 			$this->mailer->send($message);
 
-			$this->logger->info('Email reminder sent successfully', [
+			$this->logger->debug('Email reminder sent successfully', [
 				'app' => Application::APP_ID,
-				'toEmail' => $toEmail,
+				'toEmail' => self::maskEmail($toEmail),
 				'contractId' => $contract->getId(),
 				'reminderType' => $reminderType,
 			]);
@@ -110,12 +110,35 @@ class EmailService {
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to send email reminder: ' . $e->getMessage(), [
 				'app' => Application::APP_ID,
-				'toEmail' => $toEmail,
+				'toEmail' => self::maskEmail($toEmail),
 				'contractId' => $contract->getId(),
 				'exception' => $e,
 			]);
 			return false;
 		}
+	}
+
+	/**
+	 * Mask an email address for log output: keep first char of local part,
+	 * the domain TLD, and obfuscate the rest. Examples:
+	 *   axel@example.com → a***@e***.com
+	 *   a@b.de           → a***@b***.de
+	 *   (invalid)        → ***
+	 */
+	public static function maskEmail(string $email): string {
+		$at = strrpos($email, '@');
+		if ($at === false || $at === 0 || $at === strlen($email) - 1) {
+			return '***';
+		}
+		$local = substr($email, 0, $at);
+		$domain = substr($email, $at + 1);
+		$dot = strrpos($domain, '.');
+		if ($dot === false || $dot === 0) {
+			return $local[0] . '***@***';
+		}
+		$domainName = substr($domain, 0, $dot);
+		$tld = substr($domain, $dot);
+		return $local[0] . '***@' . $domainName[0] . '***' . $tld;
 	}
 
 	/**

--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -62,6 +62,7 @@ class ReminderService {
 					$this->logger->error('Failed to send first reminder: ' . $e->getMessage(), [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
+						'exception' => $e,
 					]);
 				}
 			}
@@ -80,6 +81,7 @@ class ReminderService {
 					$this->logger->error('Failed to send final reminder: ' . $e->getMessage(), [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
+						'exception' => $e,
 					]);
 				}
 			}

--- a/lib/Service/ReminderService.php
+++ b/lib/Service/ReminderService.php
@@ -54,15 +54,14 @@ class ReminderService {
 					$this->sendReminders($contract, 'first');
 					$this->markReminderSent($contract, 'first');
 					$remindersSent++;
-					$this->logger->info('Sent first cancellation reminder for contract: ' . $contract->getName(), [
+					$this->logger->debug('Sent first cancellation reminder', [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
 					]);
 				} catch (\Exception $e) {
-					$this->logger->error('Failed to send first reminder for contract: ' . $contract->getName(), [
+					$this->logger->error('Failed to send first reminder: ' . $e->getMessage(), [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
-						'exception' => $e->getMessage(),
 					]);
 				}
 			}
@@ -73,15 +72,14 @@ class ReminderService {
 					$this->sendReminders($contract, 'final');
 					$this->markReminderSent($contract, 'final');
 					$remindersSent++;
-					$this->logger->info('Sent final cancellation reminder for contract: ' . $contract->getName(), [
+					$this->logger->debug('Sent final cancellation reminder', [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
 					]);
 				} catch (\Exception $e) {
-					$this->logger->error('Failed to send final reminder for contract: ' . $contract->getName(), [
+					$this->logger->error('Failed to send final reminder: ' . $e->getMessage(), [
 						'app' => Application::APP_ID,
 						'contractId' => $contract->getId(),
-						'exception' => $e->getMessage(),
 					]);
 				}
 			}

--- a/tests/Unit/Service/EmailServiceTest.php
+++ b/tests/Unit/Service/EmailServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\Service;
+
+use OCA\ContractManager\Service\EmailService;
+use PHPUnit\Framework\TestCase;
+
+class EmailServiceTest extends TestCase {
+
+	// ========================================
+	// Email Masking for Logs (Issue #125)
+	// ========================================
+
+	public function testMaskEmailKeepsFirstCharAndTld(): void {
+		$this->assertSame('a***@e***.com', EmailService::maskEmail('axel@example.com'));
+		$this->assertSame('j***@c***.de', EmailService::maskEmail('john.doe@company.de'));
+		$this->assertSame('s***@s***.org', EmailService::maskEmail('support@some-org.org'));
+	}
+
+	public function testMaskEmailHandlesShortAddresses(): void {
+		$this->assertSame('a***@b***.de', EmailService::maskEmail('a@b.de'));
+	}
+
+	public function testMaskEmailHandlesMultiLevelDomain(): void {
+		// TLD is the last dotted segment; intermediate subdomains get collapsed
+		$result = EmailService::maskEmail('axel@mail.bedethi.com');
+		$this->assertStringStartsWith('a***@', $result);
+		$this->assertStringEndsWith('.com', $result);
+		$this->assertStringNotContainsString('bedethi', $result);
+		$this->assertStringNotContainsString('mail.', $result);
+	}
+
+	public function testMaskEmailHandlesInvalidInput(): void {
+		$this->assertSame('***', EmailService::maskEmail(''));
+		$this->assertSame('***', EmailService::maskEmail('no-at-sign'));
+		$this->assertSame('***', EmailService::maskEmail('@example.com'));
+		$this->assertSame('***', EmailService::maskEmail('user@'));
+	}
+
+	public function testMaskEmailHandlesDomainWithoutTld(): void {
+		$this->assertSame('u***@***', EmailService::maskEmail('user@localhost'));
+	}
+
+	public function testMaskEmailDoesNotLeakOriginal(): void {
+		$original = 'sensitive.user@confidential-domain.example';
+		$masked = EmailService::maskEmail($original);
+		$this->assertStringNotContainsString('sensitive', $masked);
+		$this->assertStringNotContainsString('confidential', $masked);
+	}
+}


### PR DESCRIPTION
## Summary

- `EmailService` Success-Log: `info` → `debug`, `toEmail` über `maskEmail()` maskiert (`axel@example.com` → `a***@e***.com`)
- `EmailService` Error-Log: maskiert, bleibt `error`
- `ReminderService` Success/Error-Logs: Vertragsname raus, `contractId` bleibt für Korrelation
- 6 neue Unit-Tests in `EmailServiceTest` für `maskEmail()`

## Test plan

- [x] Vollständige PHPUnit-Suite läuft grün (83 Tests, 149 Assertions)
- [x] PHP lint OK
- [x] maskEmail deckt invalid input, kurze Adressen, Multi-Level-Domains ab

Fixes #125