### PR TITLE
fix(security): extract API key mask into named constant (#126)

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -110,7 +110,7 @@ class SettingsController extends Controller {
 			'customFieldLabel2' => $this->settingsService->getCustomFieldLabel(2),
 			'customFieldLabel3' => $this->settingsService->getCustomFieldLabel(3),
 			'aiProvider' => $this->settingsService->getAiProvider(),
-			'aiApiKey' => $this->settingsService->getAiApiKey() !== '' ? '••••••••' : '',
+			'aiApiKey' => $this->settingsService->getAiApiKey() !== '' ? SettingsService::API_KEY_MASK : '',
 			'aiApiUrl' => $this->settingsService->getAiApiUrl(),
 			'aiModel' => $this->settingsService->getAiModel(),
 		]);
@@ -160,8 +160,9 @@ class SettingsController extends Controller {
 			$this->settingsService->setAiProvider($aiProvider);
 		}
 
-		// Only update API key if it's not the masked placeholder
-		if ($aiApiKey !== null && $aiApiKey !== '••••••••') {
+		// Only update API key if it's not the masked placeholder echoed back
+		// by the frontend after a getAdmin() call (see SettingsService::API_KEY_MASK).
+		if ($aiApiKey !== null && $aiApiKey !== SettingsService::API_KEY_MASK) {
 			$this->settingsService->setAiApiKey($aiApiKey);
 		}
 
@@ -181,7 +182,7 @@ class SettingsController extends Controller {
 			'customFieldLabel2' => $this->settingsService->getCustomFieldLabel(2),
 			'customFieldLabel3' => $this->settingsService->getCustomFieldLabel(3),
 			'aiProvider' => $this->settingsService->getAiProvider(),
-			'aiApiKey' => $this->settingsService->getAiApiKey() !== '' ? '••••••••' : '',
+			'aiApiKey' => $this->settingsService->getAiApiKey() !== '' ? SettingsService::API_KEY_MASK : '',
 			'aiApiUrl' => $this->settingsService->getAiApiUrl(),
 			'aiModel' => $this->settingsService->getAiModel(),
 		]);

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -16,6 +16,13 @@ use OCP\IConfig;
  */
 class SettingsService {
 
+	/**
+	 * Placeholder string returned from getAdmin() when an API key is configured,
+	 * so the secret value never leaves the server. updateAdmin() compares
+	 * incoming values against this constant to detect unchanged-key submissions.
+	 */
+	public const API_KEY_MASK = '••••••••';
+
 	private const KEY_TALK_CHAT_TOKEN = 'talk_chat_token';
 	private const KEY_REMINDER_DAYS_1 = 'reminder_days_1';
 	private const KEY_REMINDER_DAYS_2 = 'reminder_days_2';

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\Controller;
+
+use OCA\ContractManager\Controller\SettingsController;
+use OCA\ContractManager\Service\PermissionService;
+use OCA\ContractManager\Service\SettingsService;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+
+class SettingsControllerTest extends TestCase {
+
+	private IRequest $request;
+	private SettingsService $settingsService;
+	private PermissionService $permissionService;
+	private IUserManager $userManager;
+	private IGroupManager $groupManager;
+	private SettingsController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->controller = new SettingsController(
+			$this->request,
+			'admin',
+			$this->settingsService,
+			$this->permissionService,
+			$this->userManager,
+			$this->groupManager,
+		);
+	}
+
+	// ========================================
+	// API Key Masking (Issue #126)
+	// ========================================
+
+	public function testGetAdminReturnsMaskWhenKeyIsSet(): void {
+		$this->settingsService->method('getAiApiKey')->willReturn('sk-real-secret-123');
+
+		/** @var JSONResponse $response */
+		$response = $this->controller->getAdmin();
+		$data = $response->getData();
+
+		$this->assertSame(SettingsService::API_KEY_MASK, $data['aiApiKey']);
+		$this->assertStringNotContainsString('sk-real-secret-123', json_encode($data));
+	}
+
+	public function testGetAdminReturnsEmptyWhenKeyIsNotSet(): void {
+		$this->settingsService->method('getAiApiKey')->willReturn('');
+
+		/** @var JSONResponse $response */
+		$response = $this->controller->getAdmin();
+		$data = $response->getData();
+
+		$this->assertSame('', $data['aiApiKey']);
+	}
+
+	public function testUpdateAdminIgnoresMaskedKey(): void {
+		$this->settingsService->expects($this->never())->method('setAiApiKey');
+
+		$this->controller->updateAdmin(aiApiKey: SettingsService::API_KEY_MASK);
+	}
+
+	public function testUpdateAdminSavesRealKey(): void {
+		$this->settingsService->expects($this->once())
+			->method('setAiApiKey')
+			->with('sk-new-key-456');
+
+		$this->controller->updateAdmin(aiApiKey: 'sk-new-key-456');
+	}
+
+	public function testUpdateAdminIgnoresNullKey(): void {
+		$this->settingsService->expects($this->never())->method('setAiApiKey');
+
+		$this->controller->updateAdmin(aiApiKey: null);
+	}
+
+	public function testUpdateAdminClearsKeyWhenEmptyString(): void {
+		$this->settingsService->expects($this->once())
+			->method('setAiApiKey')
+			->with('');
+
+		$this->controller->updateAdmin(aiApiKey: '');
+	}
+
+	public function testApiKeyMaskConstantIsStable(): void {
+		// Pinning the value here so any accidental rename/edit is caught.
+		// The frontend echoes this exact string back; changing it silently
+		// would break the unchanged-key detection.
+		$this->assertSame('••••••••', SettingsService::API_KEY_MASK);
+	}
+}


### PR DESCRIPTION
## Summary

- Neue Konstante `SettingsService::API_KEY_MASK = '••••••••'` als Single Source of Truth
- `SettingsController::getAdmin()` (2 Stellen) und `updateAdmin()` referenzieren die Konstante
- Verhalten unverändert: Maske-Submission wird ignoriert, echte Werte überschreiben, leerer String löscht, null skippt
- 7 neue Unit-Tests in neuem `SettingsControllerTest`

## Test plan

- [x] Vollständige PHPUnit-Suite läuft grün (84 Tests, 142 Assertions)
- [x] PHP lint OK
- [x] Tests decken alle 4 Pfade ab: null / leer / Maske / realer Key

Fixes #126