### PR TITLE
chore(tooling): bootstrap Vitest with smoke tests for Pinia stores

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,4 +14,13 @@ module.exports = {
 		// explicitly unused parameters kept for binding/contract parity.
 		'no-void': 'off',
 	},
+	overrides: [
+		{
+			// Test files and the shared test setup are allowed to import devDependencies.
+			files: ['src/**/*.{test,spec}.{ts,js}', 'src/test/**/*.{ts,js}'],
+			rules: {
+				'n/no-unpublished-import': 'off',
+			},
+		},
+	],
 }

--- a/src/store/categories.test.ts
+++ b/src/store/categories.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import CategoryService from '../services/CategoryService.js'
+import { useCategoriesStore } from './categories'
+
+vi.mock('../services/CategoryService.js', () => ({
+	default: {
+		getAll: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	},
+}))
+
+const mockedService = vi.mocked(CategoryService)
+
+describe('categories store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		vi.clearAllMocks()
+	})
+
+	it('starts empty and not loading', () => {
+		const store = useCategoriesStore()
+		expect(store.allCategories).toEqual([])
+		expect(store.isLoading).toBe(false)
+		expect(store.error).toBeNull()
+	})
+
+	it('fetchCategories populates state from the service', async () => {
+		mockedService.getAll.mockResolvedValue([
+			{ id: 1, name: 'Versicherung' },
+			{ id: 2, name: 'Telekommunikation' },
+		])
+		const store = useCategoriesStore()
+
+		await store.fetchCategories()
+
+		expect(store.allCategories).toHaveLength(2)
+		expect(store.allCategories[0].name).toBe('Versicherung')
+		expect(store.isLoading).toBe(false)
+	})
+
+	it('getCategoryName returns the matching name or empty string', async () => {
+		mockedService.getAll.mockResolvedValue([{ id: 7, name: 'Sonstige' }])
+		const store = useCategoriesStore()
+		await store.fetchCategories()
+
+		expect(store.getCategoryName(7)).toBe('Sonstige')
+		expect(store.getCategoryName(999)).toBe('')
+	})
+
+	it('createCategory appends to state on success', async () => {
+		mockedService.create.mockResolvedValue({ id: 42, name: 'Neu' })
+		const store = useCategoriesStore()
+
+		const created = await store.createCategory('Neu')
+
+		expect(created).toEqual({ id: 42, name: 'Neu' })
+		expect(store.allCategories).toContainEqual({ id: 42, name: 'Neu' })
+	})
+
+	it('createCategory records the error and rethrows on failure', async () => {
+		mockedService.create.mockRejectedValue(new Error('boom'))
+		const store = useCategoriesStore()
+
+		await expect(store.createCategory('x')).rejects.toThrow('boom')
+		expect(store.error).toBe('boom')
+		expect(store.isLoading).toBe(false)
+	})
+})

--- a/src/store/contracts.test.ts
+++ b/src/store/contracts.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import ContractService from '../services/ContractService.js'
+import { useContractsStore, type Contract } from './contracts'
+
+vi.mock('../services/ContractService.js', () => ({
+	default: {
+		getAll: vi.fn(),
+		getArchived: vi.fn(),
+		getTrashed: vi.fn(),
+		get: vi.fn(),
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		archive: vi.fn(),
+		restore: vi.fn(),
+		restoreFromTrash: vi.fn(),
+		deletePermanently: vi.fn(),
+		emptyTrash: vi.fn(),
+		getPermissions: vi.fn(),
+	},
+}))
+
+const mockedService = vi.mocked(ContractService)
+
+const contract = (id: number, overrides: Partial<Contract> = {}): Contract => ({
+	id,
+	status: 'active',
+	archived: false,
+	...overrides,
+})
+
+describe('contracts store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		vi.clearAllMocks()
+	})
+
+	it('starts with empty lists and default permissions', () => {
+		const store = useContractsStore()
+		expect(store.allContracts).toEqual([])
+		expect(store.archivedContracts).toEqual([])
+		expect(store.trashedContracts).toEqual([])
+		expect(store.isAdmin).toBe(false)
+		expect(store.canEdit).toBe(false)
+	})
+
+	it('getContractById finds the matching contract', async () => {
+		mockedService.getAll.mockResolvedValue([contract(1), contract(2), contract(3)])
+		const store = useContractsStore()
+		await store.fetchContracts()
+
+		expect(store.getContractById(2)?.id).toBe(2)
+		expect(store.getContractById(99)).toBeUndefined()
+	})
+
+	it('archiveContract moves the contract from active to archived', async () => {
+		mockedService.getAll.mockResolvedValue([contract(1), contract(2)])
+		mockedService.archive.mockResolvedValue(contract(1, { archived: true }))
+		const store = useContractsStore()
+		await store.fetchContracts()
+
+		await store.archiveContract(1)
+
+		expect(store.allContracts.map((c) => c.id)).toEqual([2])
+		expect(store.archivedContracts.map((c) => c.id)).toEqual([1])
+	})
+
+	it('deleteContract removes the contract from active and archived lists', async () => {
+		mockedService.getAll.mockResolvedValue([contract(1), contract(2)])
+		mockedService.delete.mockResolvedValue(undefined)
+		const store = useContractsStore()
+		await store.fetchContracts()
+		store.archivedContracts.push(contract(3))
+
+		await store.deleteContract(1)
+
+		expect(store.allContracts.map((c) => c.id)).toEqual([2])
+		expect(store.archivedContracts.map((c) => c.id)).toEqual([3])
+	})
+
+	it('fetchPermissions reflects backend permissions in computed getters', async () => {
+		mockedService.getPermissions.mockResolvedValue({
+			isAdmin: true,
+			isEditor: true,
+			isViewer: true,
+			canEdit: true,
+			canDeletePermanently: true,
+		})
+		const store = useContractsStore()
+
+		await store.fetchPermissions()
+
+		expect(store.isAdmin).toBe(true)
+		expect(store.canEdit).toBe(true)
+		expect(store.canDeletePermanently).toBe(true)
+	})
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+// Nextcloud globals injected at runtime by the server (templates/main.php).
+// In tests we provide minimal stand-ins so code that calls them doesn't crash.
+;(globalThis as Record<string, unknown>).t = (_app: string, text: string) => text
+;(globalThis as Record<string, unknown>).n = (_app: string, sg: string, pl: string, count: number) =>
+	count === 1 ? sg : pl
+;(globalThis as Record<string, unknown>).OC = { requestToken: 'test-token' }
+
+// Stub the Nextcloud helper modules used by the service layer.
+// Tests that touch services should override these with vi.mocked() per-suite.
+vi.mock('@nextcloud/axios', () => ({
+	default: {
+		get: vi.fn(),
+		post: vi.fn(),
+		put: vi.fn(),
+		delete: vi.fn(),
+	},
+}))
+
+vi.mock('@nextcloud/router', () => ({
+	generateUrl: (path: string) => path,
+	generateRemoteUrl: (path: string) => path,
+}))

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,16 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
 export default defineConfig({
   plugins: [vue()],
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,js}'],
+  },
   define: {
     'process.env': {},
     '__VUE_OPTIONS_API__': true,


### PR DESCRIPTION
Schließt den letzten offenen Punkt aus #161. Bisher lief `npm test` mit „No test files found" ins Leere — die Vitest-Konfiguration wurde bei der Vue-3-Migration nicht migriert und die alten Jest-Tests nicht portiert.

## Was reinkommt

**Vitest-Konfiguration**
- `test`-Block in `vite.config.js`: happy-dom-Environment, globale APIs, Setup-File, Discovery-Pattern `src/**/*.{test,spec}.{ts,js}`

**Test-Setup `src/test/setup.ts`**
- Stub für Nextcloud-Globals (`t`, `n`, `OC`)
- `vi.mock` für `@nextcloud/axios` und `@nextcloud/router`, damit Service-Layer-Imports unter dem Runner nicht crashen

**ESLint-Override**
- `n/no-unpublished-import` aus für `src/**/*.test.ts` und `src/test/*` (Tests dürfen devDependencies importieren)

**Smoke-Tests für beide Pinia-Stores** (`categories.ts`, `contracts.ts`)
- Initial-State
- Fetch füllt State
- Getter (`getCategoryName`, `getContractById`)
- Mutating Actions (`archiveContract`, `deleteContract`, `fetchPermissions`)
- Error-Propagation

## Status

```
test:       10/10 passed (~600ms)
lint:       0 errors, 0 warnings
typecheck:  clean
build:      grün
```

## Was bewusst draußen bleibt

Coverage ist absichtlich flach. Ziel ist ein arbeitendes Harness, nicht Vollabdeckung. Komponenten-Tests und tieferer Store-Test sind ein Folge-Track.

Closes #161