### PR TITLE
chore(controllers): migrate @NoAdminRequired docblocks to PHP attributes

### DIFF
--- a/lib/Controller/CategoryController.php
+++ b/lib/Controller/CategoryController.php
@@ -9,6 +9,7 @@ use OCA\ContractManager\Service\CategoryService;
 use OCA\ContractManager\Service\NotFoundException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -22,9 +23,7 @@ class CategoryController extends Controller {
         parent::__construct(Application::APP_ID, $request);
     }
 
-    /**
-     * @NoAdminRequired
-     */
+    #[NoAdminRequired]
     public function index(): JSONResponse {
         return new JSONResponse($this->service->findAll());
     }

--- a/lib/Controller/ContractController.php
+++ b/lib/Controller/ContractController.php
@@ -12,6 +12,7 @@ use OCA\ContractManager\Service\PermissionService;
 use OCA\ContractManager\Service\ValidationException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -30,9 +31,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Get all visible contracts
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function index(): JSONResponse {
 		$isAdmin = $this->permissionService->isAdmin($this->userId);
 		return new JSONResponse($this->service->findAllVisible($this->userId, $isAdmin));
@@ -40,9 +40,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Get all visible archived contracts
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function archived(): JSONResponse {
 		$isAdmin = $this->permissionService->isAdmin($this->userId);
 		return new JSONResponse($this->service->findArchivedVisible($this->userId, $isAdmin));
@@ -50,9 +49,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Get contracts in trash (user sees own, admin sees all)
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function trash(): JSONResponse {
 		$isAdmin = $this->permissionService->isAdmin($this->userId);
 
@@ -65,9 +63,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Get user permissions info for frontend
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function permissions(): JSONResponse {
 		return new JSONResponse($this->permissionService->getPermissionInfo($this->userId));
 	}
@@ -75,9 +72,8 @@ class ContractController extends Controller {
 	/**
 	 * Distinct vendor names from contracts visible to the user.
 	 * Powers the autocomplete in the contract form.
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function vendors(): JSONResponse {
 		$isAdmin = $this->permissionService->isAdmin($this->userId);
 		return new JSONResponse($this->service->findVisibleVendors($this->userId, $isAdmin));
@@ -85,9 +81,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Get a single contract
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function show(int $id): JSONResponse {
 		try {
 			$contract = $this->service->find($id);
@@ -105,9 +100,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Create a new contract (Editor or Admin)
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function create(
 		string $name,
 		string $vendor,
@@ -189,9 +183,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Update a contract (Editor or Admin, with visibility rules)
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function update(
 		int $id,
 		string $name,
@@ -283,9 +276,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Soft-delete a contract (move to trash)
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function destroy(int $id): JSONResponse {
 		try {
 			$contract = $this->service->find($id);
@@ -305,9 +297,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Restore a contract from trash (user can restore own, admin can restore all)
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function restoreFromTrash(int $id): JSONResponse {
 		try {
 			$contract = $this->service->find($id);
@@ -326,7 +317,7 @@ class ContractController extends Controller {
 
 	/**
 	 * Permanently delete a contract (Admin only)
-	 * No @NoAdminRequired annotation = Nextcloud enforces admin check
+	 * No #[NoAdminRequired] attribute = Nextcloud enforces admin check
 	 */
 	public function deletePermanently(int $id): JSONResponse {
 		try {
@@ -339,7 +330,7 @@ class ContractController extends Controller {
 
 	/**
 	 * Empty trash (permanently delete all trashed contracts) (Admin only)
-	 * No @NoAdminRequired annotation = Nextcloud enforces admin check
+	 * No #[NoAdminRequired] attribute = Nextcloud enforces admin check
 	 */
 	public function emptyTrash(): JSONResponse {
 		$count = $this->service->emptyTrash();
@@ -348,9 +339,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Archive a contract
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function archive(int $id): JSONResponse {
 		try {
 			$contract = $this->service->find($id);
@@ -370,9 +360,8 @@ class ContractController extends Controller {
 
 	/**
 	 * Restore a contract from archive
-	 *
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function restore(int $id): JSONResponse {
 		try {
 			$contract = $this->service->find($id);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -8,6 +8,8 @@ use OCA\ContractManager\AppInfo\Application;
 use OCA\ContractManager\Service\SettingsService;
 use OCA\Viewer\Event\LoadViewer;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -28,10 +30,8 @@ class PageController extends Controller {
 		parent::__construct(Application::APP_ID, $request);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function index(): TemplateResponse {
 		Util::addScript(Application::APP_ID, 'contractmanager-main');
 		Util::addStyle(Application::APP_ID, 'contractmanager-main');

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -28,7 +28,7 @@ class SettingsController extends Controller {
 	}
 
 	// ========================================
-	// User Settings (mit @NoAdminRequired)
+	// User Settings (mit #[NoAdminRequired])
 	// ========================================
 
 	/**
@@ -91,12 +91,12 @@ class SettingsController extends Controller {
 	}
 
 	// ========================================
-	// Admin Settings (ohne @NoAdminRequired = nur Admins)
+	// Admin Settings (ohne #[NoAdminRequired] = nur Admins)
 	// ========================================
 
 	/**
 	 * Get admin settings
-	 * No @NoAdminRequired = only admins can access
+	 * No #[NoAdminRequired] = only admins can access
 	 *
 	 * Note: User access control is now handled via Nextcloud's native
 	 * group-based app access (Admin → Apps → "Enable only for specific groups")
@@ -118,7 +118,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * Update admin settings
-	 * No @NoAdminRequired = only admins can access
+	 * No #[NoAdminRequired] = only admins can access
 	 */
 	public function updateAdmin(
 		?string $talkChatToken = null,
@@ -194,7 +194,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * Get permission settings (editors and viewers)
-	 * No @NoAdminRequired = only admins can access
+	 * No #[NoAdminRequired] = only admins can access
 	 */
 	public function getPermissions(): JSONResponse {
 		return new JSONResponse([
@@ -205,7 +205,7 @@ class SettingsController extends Controller {
 
 	/**
 	 * Update permission settings
-	 * No @NoAdminRequired = only admins can access
+	 * No #[NoAdminRequired] = only admins can access
 	 *
 	 * @param string[] $editors Array of "group:groupId" or "user:userId" entries
 	 * @param string[] $viewers Array of "group:groupId" or "user:userId" entries
@@ -231,7 +231,7 @@ class SettingsController extends Controller {
 	/**
 	 * Search for users and groups
 	 * Used by the permission picker in settings
-	 * No @NoAdminRequired = only admins can access
+	 * No #[NoAdminRequired] = only admins can access
 	 */
 	public function searchPrincipals(string $query = ''): JSONResponse {
 		$results = [];


### PR DESCRIPTION
Tech-Debt-Punkt 1 aus #155. Vier der fünf Controller nutzten noch die alten `@NoAdminRequired` / `@NoCSRFRequired` Docblock-Annotationen (seit NC 30 deprecated, ersetzt durch die PHP-8-Attribute `#[NoAdminRequired]` / `#[NoCSRFRequired]`). `ExtractionController` und die User-Methoden des `SettingsController` waren schon migriert — jetzt sind die anderen drei nachgezogen.

## Geändert

- **`ContractController.php`** — 12 Methoden migriert, Attribut-Import ergänzt
- **`CategoryController.php`** — 1 Methode migriert, Import ergänzt
- **`PageController.php`** — `index()` migriert (beide Annotationen), zwei Imports
- **`SettingsController.php`** — nur Inline-Kommentare aktualisiert, die noch die alte Syntax erwähnten; kein Verhaltens-Change

Die bestehenden Erklär-Kommentare an `ContractController.php` Z. 320 / 333 („Ohne <annotation> → Admin-Check") wurden ebenfalls auf die neue Syntax aktualisiert, sodass die Doku zum Code passt.

## Status

- `php -l` clean auf allen vier Files
- lint: 0 / 0
- typecheck: clean
- tests: 11/11
- build: grün

Refs #155