### PR TITLE
fix(status): ausgelaufene Verträge automatisch archivieren (#176)

### DIFF
--- a/lib/BackgroundJob/StatusUpdateJob.php
+++ b/lib/BackgroundJob/StatusUpdateJob.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Background job that runs once per day and:
- * - sets expired fixed contracts to "ended"
+ * - sets expired fixed contracts to "ended" and archives them (issue #176)
  * - ends and archives cancelled contracts once their effective termination
  *   date is reached (issue #136)
  */
@@ -41,11 +41,13 @@ class StatusUpdateJob extends TimedJob {
 
 			foreach ($expiredContracts as $contract) {
 				$contract->setStatus('ended');
+				// Auto-archive expired contracts, consistent with cancelled ones (#176).
+				$contract->setArchived(true);
 				$contract->setUpdatedAt(new DateTime());
 				$this->contractMapper->update($contract);
 				$updatedCount++;
 
-				$this->logger->info('Contract status set to ended: ' . $contract->getName(), [
+				$this->logger->info('Contract status set to ended and archived: ' . $contract->getName(), [
 					'app' => Application::APP_ID,
 					'contractId' => $contract->getId(),
 					'endDate' => $contract->getEndDate()?->format('Y-m-d'),

--- a/lib/Db/ContractMapper.php
+++ b/lib/Db/ContractMapper.php
@@ -280,7 +280,8 @@ class ContractMapper extends QBMapper {
         $qb->select('*')
             ->from($this->getTableName())
             ->where($qb->expr()->eq('status', $qb->createNamedParameter(Contract::STATUS_ACTIVE)))
-            ->andWhere($qb->expr()->eq('contract_type', $qb->createNamedParameter('fixed')))
+            ->andWhere($qb->expr()->eq('contract_type', $qb->createNamedParameter(Contract::TYPE_FIXED)))
+            ->andWhere($qb->expr()->eq('archived', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
             ->andWhere($qb->expr()->lt('end_date', $qb->createNamedParameter(new \DateTime(), IQueryBuilder::PARAM_DATE)))
             ->andWhere($qb->expr()->isNull('deleted_at'));
 

--- a/tests/Unit/BackgroundJob/StatusUpdateJobTest.php
+++ b/tests/Unit/BackgroundJob/StatusUpdateJobTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\BackgroundJob;
+
+use OCA\ContractManager\BackgroundJob\StatusUpdateJob;
+use OCA\ContractManager\Db\Contract;
+use OCA\ContractManager\Db\ContractMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class StatusUpdateJobTest extends TestCase {
+
+	private ContractMapper $contractMapper;
+	private StatusUpdateJob $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$time = $this->createMock(ITimeFactory::class);
+		$this->contractMapper = $this->createMock(ContractMapper::class);
+		$logger = $this->createMock(LoggerInterface::class);
+		$this->job = new StatusUpdateJob($time, $this->contractMapper, $logger);
+	}
+
+	/**
+	 * #176: An expired fixed contract must be set to "ended" AND archived,
+	 * consistent with how cancelled contracts are handled.
+	 */
+	public function testExpiredFixedContractIsEndedAndArchived(): void {
+		$contract = new Contract();
+		$contract->setName('Abgelaufener Vertrag');
+		$contract->setStatus(Contract::STATUS_ACTIVE);
+		$contract->setContractType('fixed');
+		$contract->setArchived(0);
+
+		$this->contractMapper->method('findExpiredActiveFixed')->willReturn([$contract]);
+		$this->contractMapper->method('findCancelledDue')->willReturn([]);
+
+		$this->job->run(null);
+
+		$this->assertSame('ended', $contract->getStatus());
+		$this->assertTrue((bool)$contract->getArchived(), 'Expired contract should be archived');
+	}
+
+	/**
+	 * Existing behaviour (#136) must remain: cancelled-due contracts are
+	 * ended and archived.
+	 */
+	public function testCancelledDueContractIsEndedAndArchived(): void {
+		$contract = new Contract();
+		$contract->setName('Gekündigter Vertrag');
+		$contract->setStatus(Contract::STATUS_CANCELLED);
+		$contract->setArchived(0);
+
+		$this->contractMapper->method('findExpiredActiveFixed')->willReturn([]);
+		$this->contractMapper->method('findCancelledDue')->willReturn([$contract]);
+
+		$this->job->run(null);
+
+		$this->assertSame('ended', $contract->getStatus());
+		$this->assertTrue((bool)$contract->getArchived());
+	}
+}

--- a/tests/Unit/BackgroundJob/StatusUpdateJobTest.php
+++ b/tests/Unit/BackgroundJob/StatusUpdateJobTest.php
@@ -24,6 +24,10 @@ class StatusUpdateJobTest extends TestCase {
 		$this->job = new StatusUpdateJob($time, $this->contractMapper, $logger);
 	}
 
+	private function invokeRun(mixed $argument): void {
+		(new \ReflectionMethod($this->job, 'run'))->invoke($this->job, $argument);
+	}
+
 	/**
 	 * #176: An expired fixed contract must be set to "ended" AND archived,
 	 * consistent with how cancelled contracts are handled.
@@ -38,7 +42,7 @@ class StatusUpdateJobTest extends TestCase {
 		$this->contractMapper->method('findExpiredActiveFixed')->willReturn([$contract]);
 		$this->contractMapper->method('findCancelledDue')->willReturn([]);
 
-		$this->job->run(null);
+		$this->invokeRun(null);
 
 		$this->assertSame('ended', $contract->getStatus());
 		$this->assertTrue((bool)$contract->getArchived(), 'Expired contract should be archived');
@@ -57,7 +61,7 @@ class StatusUpdateJobTest extends TestCase {
 		$this->contractMapper->method('findExpiredActiveFixed')->willReturn([]);
 		$this->contractMapper->method('findCancelledDue')->willReturn([$contract]);
 
-		$this->job->run(null);
+		$this->invokeRun(null);
 
 		$this->assertSame('ended', $contract->getStatus());
 		$this->assertTrue((bool)$contract->getArchived());


### PR DESCRIPTION
## Problem
Ein regulär ausgelaufener (befristeter) Vertrag wurde auf Status "Beendet" gesetzt, blieb aber in der aktiven Vertragsliste statt ins Archiv zu wandern (#176).

## Fix
Im `StatusUpdateJob` werden ausgelaufene fixed-Verträge jetzt zusätzlich archiviert (`setArchived(true)`), genau wie es bei gekündigten Verträgen (#136) bereits geschieht.

## Test
PHPUnit-Regressionstest `tests/Unit/BackgroundJob/StatusUpdateJobTest.php`: ausgelaufener Vertrag -> ended + archiviert; gekündigter Vertrag (Bestandsverhalten) -> ended + archiviert.

Fixes #176
