### PR TITLE
test(email): Unit-Test für buildContractUrl() (#189)

### DIFF
--- a/tests/Unit/Service/EmailServiceTest.php
+++ b/tests/Unit/Service/EmailServiceTest.php
@@ -99,7 +99,6 @@ class EmailServiceTest extends TestCase {
 		}
 		try {
 			$method = new ReflectionMethod(EmailService::class, 'buildContractUrl');
-			$method->setAccessible(true);
 			return $method->invoke($service, $contract);
 		} finally {
 			if ($prev === false) {
@@ -132,10 +131,5 @@ class EmailServiceTest extends TestCase {
 			'https://nc.example.test/apps/contractmanager/?contract=42',
 			$this->callBuildContractUrl(false, 'true'),
 		);
-	}
-
-	public function testBuildContractUrlAppendsContractId(): void {
-		$url = $this->callBuildContractUrl(false, null);
-		$this->assertStringEndsWith('?contract=42', $url);
 	}
 }

--- a/tests/Unit/Service/EmailServiceTest.php
+++ b/tests/Unit/Service/EmailServiceTest.php
@@ -4,8 +4,17 @@ declare(strict_types=1);
 
 namespace OCA\ContractManager\Tests\Unit\Service;
 
+use OCA\ContractManager\Db\Contract;
 use OCA\ContractManager\Service\EmailService;
+use OCA\ContractManager\Service\SettingsService;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Mail\IMailer;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
 
 class EmailServiceTest extends TestCase {
 
@@ -48,5 +57,85 @@ class EmailServiceTest extends TestCase {
 		$masked = EmailService::maskEmail($original);
 		$this->assertStringNotContainsString('sensitive', $masked);
 		$this->assertStringNotContainsString('confidential', $masked);
+	}
+
+	// ========================================
+	// Deep-link URL building for reminder mails (Issue #187, #189)
+	// ========================================
+
+	/**
+	 * Invoke the private buildContractUrl() with controlled front-controller
+	 * settings. getAbsoluteURL() is stubbed to echo its argument behind a fixed
+	 * host, so the assertion targets exactly the path buildContractUrl builds.
+	 */
+	private function callBuildContractUrl(bool $ignoreFrontController, ?string $frontControllerEnv): string {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueBool')
+			->with('htaccess.IgnoreFrontController', false)
+			->willReturn($ignoreFrontController);
+
+		$url = $this->createMock(IURLGenerator::class);
+		$url->method('getAbsoluteURL')
+			->willReturnCallback(static fn (string $path): string => 'https://nc.example.test' . $path);
+
+		$service = new EmailService(
+			$this->createMock(IMailer::class),
+			$this->createMock(IUserManager::class),
+			$url,
+			$config,
+			$this->createMock(IFactory::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$contract = new Contract();
+		$contract->setId(42);
+
+		$prev = getenv('front_controller_active');
+		if ($frontControllerEnv === null) {
+			putenv('front_controller_active');
+		} else {
+			putenv('front_controller_active=' . $frontControllerEnv);
+		}
+		try {
+			$method = new ReflectionMethod(EmailService::class, 'buildContractUrl');
+			$method->setAccessible(true);
+			return $method->invoke($service, $contract);
+		} finally {
+			if ($prev === false) {
+				putenv('front_controller_active');
+			} else {
+				putenv('front_controller_active=' . $prev);
+			}
+		}
+	}
+
+	public function testBuildContractUrlUsesIndexPhpWhenFrontControllerInactive(): void {
+		// Default instance (mod_rewrite off): path must include /index.php
+		$this->assertSame(
+			'https://nc.example.test/index.php/apps/contractmanager/?contract=42',
+			$this->callBuildContractUrl(false, null),
+		);
+	}
+
+	public function testBuildContractUrlOmitsIndexPhpWhenIgnoreFrontControllerSet(): void {
+		// htaccess.IgnoreFrontController = true → no /index.php prefix
+		$this->assertSame(
+			'https://nc.example.test/apps/contractmanager/?contract=42',
+			$this->callBuildContractUrl(true, null),
+		);
+	}
+
+	public function testBuildContractUrlOmitsIndexPhpWhenFrontControllerEnvActive(): void {
+		// front_controller_active=true (env) → no /index.php prefix
+		$this->assertSame(
+			'https://nc.example.test/apps/contractmanager/?contract=42',
+			$this->callBuildContractUrl(false, 'true'),
+		);
+	}
+
+	public function testBuildContractUrlAppendsContractId(): void {
+		$url = $this->callBuildContractUrl(false, null);
+		$this->assertStringEndsWith('?contract=42', $url);
 	}
 }


### PR DESCRIPTION
Follow-up aus dem v1.0.3-Bot-Review (#188): Unit-Test-Abdeckung für die Deep-Link-URL-Logik `EmailService::buildContractUrl()`.

**Getestet:**
- Front-Controller inaktiv (Default) → Pfad mit `/index.php`
- `htaccess.IgnoreFrontController = true` → ohne `/index.php`
- `front_controller_active=true` (env) → ohne `/index.php`
- `?contract=<id>` wird angehängt

Methode ist `private` → via Reflection; `IConfig`/`IURLGenerator` gemockt. Lokal grün verifiziert (isolierte `composer install --dev` + phpunit 10.5, 10/10 EmailServiceTest).

Hinweis: Es gibt (noch) keine PHPUnit-CI; der Test läuft daher nicht automatisch. Separater Punkt — siehe PR-Beschreibung-Diskussion.

Closes #189