### PR TITLE
test(deadline): Charakterisierungs-Tests für Kündigungsdatum-Berechnung (Netz für #159)

### DIFF
--- a/src/utils/periodUtils.test.js
+++ b/src/utils/periodUtils.test.js
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	addPeriod,
+	calculateCancellationDeadline,
+	getEffectiveEndDate,
+	parsePeriod,
+	subtractPeriod,
+} from './periodUtils.js'
+
+/**
+ * Characterization tests for the cancellation-deadline calculation core.
+ *
+ * Purpose: pin the CURRENT behavior before the "Kündigen zum" feature (#159)
+ * touches this code. These tests describe what the code does today — including
+ * a couple of quirks that are deliberately documented, not fixed here. Any
+ * future change to the math must consciously update a red test rather than
+ * surprise a user.
+ *
+ * Dates are built with `new Date(year, monthIndex, day)` (local time) and
+ * asserted via local Y-M-D, so results are timezone-independent like the
+ * production code (which uses getDate()/setMonth() in local time).
+ */
+
+const FAKE_NOW = new Date(2026, 5, 15, 8, 0, 0) // 2026-06-15 local
+
+function ymd(date) {
+	if (!date) return null
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+describe('parsePeriod', () => {
+	it('parses plural and singular units', () => {
+		expect(parsePeriod('3 months')).toEqual({ value: 3, unit: 'months' })
+		expect(parsePeriod('1 month')).toEqual({ value: 1, unit: 'month' })
+		expect(parsePeriod('14 days')).toEqual({ value: 14, unit: 'days' })
+		expect(parsePeriod('2 weeks')).toEqual({ value: 2, unit: 'weeks' })
+		expect(parsePeriod('1 year')).toEqual({ value: 1, unit: 'year' })
+	})
+
+	it('tolerates missing whitespace', () => {
+		expect(parsePeriod('3months')).toEqual({ value: 3, unit: 'months' })
+	})
+
+	it('returns null for empty or invalid input', () => {
+		expect(parsePeriod(null)).toBeNull()
+		expect(parsePeriod('')).toBeNull()
+		expect(parsePeriod('soon')).toBeNull()
+		expect(parsePeriod('3 fortnights')).toBeNull()
+	})
+})
+
+describe('subtractPeriod', () => {
+	it('subtracts days, weeks and years', () => {
+		expect(ymd(subtractPeriod(new Date(2026, 5, 30), '14 days'))).toBe('2026-06-16')
+		expect(ymd(subtractPeriod(new Date(2026, 5, 30), '2 weeks'))).toBe('2026-06-16')
+		expect(ymd(subtractPeriod(new Date(2026, 5, 30), '1 year'))).toBe('2025-06-30')
+	})
+
+	it('subtracts whole months when the day-of-month exists', () => {
+		expect(ymd(subtractPeriod(new Date(2026, 5, 30), '3 months'))).toBe('2026-03-30')
+		expect(ymd(subtractPeriod(new Date(2026, 5, 30), '1 month'))).toBe('2026-05-30')
+	})
+
+	it('clamps to month end on overflow (31 Mar - 1 month → 28 Feb)', () => {
+		expect(ymd(subtractPeriod(new Date(2026, 2, 31), '1 month'))).toBe('2026-02-28')
+	})
+
+	it('clamps to Feb 29 in a leap year (31 Mar 2024 - 1 month)', () => {
+		expect(ymd(subtractPeriod(new Date(2024, 2, 31), '1 month'))).toBe('2024-02-29')
+	})
+
+	// QUIRK (documented, not fixed here): the year branch has NO leap-year
+	// guard, so 29 Feb 2024 - 1 year rolls over to 1 Mar 2023 instead of
+	// 28 Feb 2023. The PHP backend clamps this differently — see the note in
+	// the impact analysis for #159.
+	it('does NOT guard leap years on year subtraction (29 Feb - 1 year → 1 Mar)', () => {
+		expect(ymd(subtractPeriod(new Date(2024, 1, 29), '1 year'))).toBe('2023-03-01')
+	})
+
+	it('returns null for an unparseable period', () => {
+		expect(subtractPeriod(new Date(2026, 5, 30), 'bogus')).toBeNull()
+	})
+})
+
+describe('addPeriod', () => {
+	it('adds days, weeks, months and years', () => {
+		expect(ymd(addPeriod(new Date(2026, 0, 1), '10 days'))).toBe('2026-01-11')
+		expect(ymd(addPeriod(new Date(2026, 0, 1), '2 weeks'))).toBe('2026-01-15')
+		expect(ymd(addPeriod(new Date(2026, 0, 21), '12 months'))).toBe('2027-01-21')
+		expect(ymd(addPeriod(new Date(2026, 0, 1), '1 year'))).toBe('2027-01-01')
+	})
+
+	it('clamps to month end on overflow (31 Jan + 1 month → 28 Feb)', () => {
+		expect(ymd(addPeriod(new Date(2026, 0, 31), '1 month'))).toBe('2026-02-28')
+	})
+})
+
+describe('getEffectiveEndDate', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(FAKE_NOW)
+	})
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('returns the end date unchanged for fixed contracts', () => {
+		expect(ymd(getEffectiveEndDate(new Date(2026, 10, 21), 'fixed', null))).toBe('2026-11-21')
+	})
+
+	it('returns a future end date unchanged for auto_renewal', () => {
+		expect(ymd(getEffectiveEndDate(new Date(2026, 10, 21), 'auto_renewal', '12 months'))).toBe('2026-11-21')
+	})
+
+	it('rolls a past auto_renewal end date forward into the future', () => {
+		// 2024-01-21 + 12-month renewals → first end after 2026-06-15 is 2027-01-21.
+		expect(ymd(getEffectiveEndDate(new Date(2024, 0, 21), 'auto_renewal', '12 months'))).toBe('2027-01-21')
+	})
+
+	it('uses cancelledTo as the effective end for cancelled contracts', () => {
+		const result = getEffectiveEndDate(new Date(2026, 10, 21), 'auto_renewal', '12 months', {
+			status: 'cancelled',
+			cancelledTo: new Date(2026, 7, 31),
+		})
+		expect(ymd(result)).toBe('2026-08-31')
+	})
+
+	it('falls back to the end date for cancelled contracts without cancelledTo', () => {
+		const result = getEffectiveEndDate(new Date(2026, 10, 21), 'auto_renewal', '12 months', { status: 'cancelled' })
+		expect(ymd(result)).toBe('2026-11-21')
+	})
+
+	it('returns null without an end date', () => {
+		expect(getEffectiveEndDate(null, 'auto_renewal', '12 months')).toBeNull()
+	})
+})
+
+describe('calculateCancellationDeadline', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(FAKE_NOW)
+	})
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('returns null without end date or cancellation period', () => {
+		expect(calculateCancellationDeadline(null, '1 month', 'fixed')).toBeNull()
+		expect(calculateCancellationDeadline(new Date(2026, 10, 21), null, 'fixed')).toBeNull()
+	})
+
+	it('returns null for cancelled contracts', () => {
+		expect(calculateCancellationDeadline(new Date(2026, 10, 21), '1 month', 'auto_renewal', '12 months', { status: 'cancelled' })).toBeNull()
+	})
+
+	it('subtracts the cancellation period from a fixed end date', () => {
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 5, 30), '3 months', 'fixed'))).toBe('2026-03-30')
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 5, 30), '14 days', 'fixed'))).toBe('2026-06-16')
+	})
+
+	it('clamps the deadline to month end on overflow (fixed, 31 Mar - 1 month)', () => {
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 2, 31), '1 month', 'fixed'))).toBe('2026-02-28')
+	})
+
+	// Volker's case (#159): auto_renewal, end on the 21st, 1-month notice →
+	// today the deadline lands on the 21st of the previous month. The "Kündigen
+	// zum: zum Monatsende" feature will later turn this into 2026-10-31 WITHOUT
+	// changing this default ('normal') result.
+	it('anchors an auto_renewal deadline to the day-of-month (the 21st)', () => {
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 10, 21), '1 month', 'auto_renewal', '12 months'))).toBe('2026-10-21')
+	})
+
+	it('rolls the deadline forward when the current one already passed (auto_renewal)', () => {
+		// End 2026-06-30, 90-day notice → original deadline 2026-04-01 (past).
+		// Renews 12 months → next deadline 2027-04-01.
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 5, 30), '90 days', 'auto_renewal', '12 months'))).toBe('2027-04-01')
+	})
+
+	it('does not roll a fixed contract whose deadline is already in the past', () => {
+		// Fixed contracts simply expire; the past deadline is returned as-is.
+		expect(ymd(calculateCancellationDeadline(new Date(2026, 5, 30), '90 days', 'fixed'))).toBe('2026-04-01')
+	})
+})

--- a/tests/Unit/Service/ReminderServiceTest.php
+++ b/tests/Unit/Service/ReminderServiceTest.php
@@ -144,6 +144,68 @@ class ReminderServiceTest extends TestCase {
 		$this->assertEquals('2026-05-30', $result->format('Y-m-d'));
 	}
 
+	// --- Charakterisierung vor #159 „Kündigen zum" (Ist-Verhalten festschreiben) ---
+
+	/**
+	 * Backend clamps a leap-day year subtraction to Feb 28 (29 Feb 2024 - 1 year
+	 * → 2023-02-28). NOTE: the JS frontend does NOT clamp this and yields
+	 * 2023-03-01 — a known FE/BE divergence documented for #159, pinned here so
+	 * any future change is a conscious decision.
+	 */
+	public function testCalculateCancellationDeadlineYearLeapClampsToFeb28(): void {
+		$contract = $this->createContract(new DateTime('2024-02-29'), '1 year');
+
+		$result = $this->service->calculateCancellationDeadline($contract);
+
+		$this->assertInstanceOf(DateTime::class, $result);
+		$this->assertEquals('2023-02-28', $result->format('Y-m-d'));
+	}
+
+	/**
+	 * Volker's case (#159): a 1-month notice anchors the deadline to the same
+	 * day-of-month (the 21st), one month earlier. The "Kündigen zum: zum
+	 * Monatsende" feature will later turn this into 2026-10-31 WITHOUT changing
+	 * this default ('normal') result. Uses a fixed contract for determinism;
+	 * the month arithmetic is identical for auto_renewal.
+	 */
+	public function testCalculateCancellationDeadlineAnchorsToDayOfMonth(): void {
+		$contract = $this->createContract(new DateTime('2026-11-21'), '1 month');
+
+		$result = $this->service->calculateCancellationDeadline($contract);
+
+		$this->assertInstanceOf(DateTime::class, $result);
+		$this->assertEquals('2026-10-21', $result->format('Y-m-d'));
+	}
+
+	/**
+	 * auto_renewal rolls a long-past deadline forward until it is in the future,
+	 * preserving the anchor day-of-month. Asserted via invariants (not an
+	 * absolute date) because the backend reads the real current time.
+	 */
+	public function testCalculateCancellationDeadlineAutoRenewalRollsIntoFuture(): void {
+		$contract = $this->createContract(new DateTime('2018-11-21'), '1 month', 'auto_renewal', '12 months');
+
+		$result = $this->service->calculateCancellationDeadline($contract);
+
+		$this->assertInstanceOf(DateTime::class, $result);
+		$todayMidnight = (new DateTime('today'))->getTimestamp();
+		$this->assertGreaterThanOrEqual($todayMidnight, $result->getTimestamp(), 'rolled deadline must not be in the past');
+		$this->assertSame('21', $result->format('d'), 'anchor day-of-month is preserved');
+	}
+
+	/**
+	 * Fixed contracts simply expire and do NOT roll: a past deadline is returned
+	 * as-is (mirrors the frontend behavior).
+	 */
+	public function testCalculateCancellationDeadlineFixedDoesNotRoll(): void {
+		$contract = $this->createContract(new DateTime('2020-06-30'), '90 days', 'fixed');
+
+		$result = $this->service->calculateCancellationDeadline($contract);
+
+		$this->assertInstanceOf(DateTime::class, $result);
+		$this->assertEquals('2020-04-01', $result->format('Y-m-d'));
+	}
+
 	// ========================================
 	// shouldSendFirstReminder Tests
 	// ========================================

--- a/tests/Unit/Service/ReminderServiceTest.php
+++ b/tests/Unit/Service/ReminderServiceTest.php
@@ -404,9 +404,12 @@ class ReminderServiceTest extends TestCase {
 	}
 
 	public function testCalculateCancellationDeadlineAutoRenewal(): void {
-		// End date in the past, auto_renewal with 12 months, cancellation 3 months
-		// Use dynamic past date so the test stays date-independent
-		$endDate = new DateTime('-2 years');
+		// End date in the past, auto_renewal with 12 months, cancellation 3 months.
+		// Use the 1st of the month to avoid month-end overflow: the assertion below
+		// relies on PHP-native modify('-3 month'), which has no overflow guard, so
+		// it must agree with the service's subtractPeriodFromDate (which does clamp).
+		// Day=1 never overflows for any 3-month subtraction.
+		$endDate = (new DateTime('first day of this month'))->modify('-2 years');
 		$contract = $this->createContract($endDate, '3 months', 'auto_renewal', '12 months');
 
 		$result = $this->service->calculateCancellationDeadline($contract);


### PR DESCRIPTION
## Schritt 1 von 2 für #159 („Kündigen zum")

Reines **Sicherheitsnetz** vor dem Feature: schreibt das **heutige** Verhalten der Kündigungsdatum-Berechnung fest, damit der spätere additive Umbau keine bestehenden Rechenpfade unbemerkt verändert. **Keine Produktionsänderung.**

### Frontend — `src/utils/periodUtils.test.js` (neu, 24 Tests)
`parsePeriod`, `subtractPeriod`, `addPeriod`, `getEffectiveEndDate`, `calculateCancellationDeadline` — inkl. Monats-Overflow (31.03. − 1 Monat → 28./29.02.), `auto_renewal`-Rolling (fake timers) und Volkers **21.-Anker-Fall** (heute: 21. → später „zum Monatsende": 31., ohne den `normal`-Default zu ändern).

### Backend — `ReminderServiceTest.php` (+5 Tests, gesamt 39)
Schließt die Lücken: `auto_renewal`-Rolling (Invarianten, da Backend reale Zeit liest), Anker-Tag, „fixed rollt nicht", und das Backend-Leap-Year-Clamp.

### Bewusst sichtbar gemacht: FE/BE-Divergenz
`29.02.2024 − 1 Jahr` ergibt im **Frontend 01.03.2023**, im **Backend 28.02.2023**. Als Ist-Zustand gepinnt (nicht gefixt) — so wird jede künftige Änderung zu einer bewussten Entscheidung (roter Test) statt zu einem stillen Bug.

### Test
- Vitest: 53/53 (gesamt), davon 24 neu.
- PHPUnit `ReminderServiceTest`: 39/39 (isoliert im Container).
- Lint sauber.

Refs #159