### PR TITLE
feat: Nextcloud 34 unterstützen (max-version → 34)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,7 +39,7 @@ Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
     <screenshot>https://raw.githubusercontent.com/cpcMomentum/contractmanager/main/screenshots/screenshot-settings.png</screenshot>
 
     <dependencies>
-        <nextcloud min-version="32" max-version="33"/>
+        <nextcloud min-version="32" max-version="34"/>
         <php min-version="8.2"/>
     </dependencies>
 


### PR DESCRIPTION
Reiner Kompatibilitäts-Bump `max-version` 33 → 34. OCP-only/Vue 3, keine in NC 34 entfernten APIs (Grep), PHP 8.2 bleibt gültig. **Auf lokaler NC-34-Instanz ohne `--force` aktiviert und smoke-getestet** (App lädt, Daten rendern, 0 JS-Fehler). Teil des NC-34-Rollouts; volle Test-Härtung separat in #193.