### PR TITLE
fix(ci): node mit npm install (rollup-Plattform-Binary)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Abhaengigkeiten installieren
-        run: npm ci
+        run: npm install
 
       - name: ESLint
         run: npm run lint


### PR DESCRIPTION
npm ci scheiterte am fehlenden Linux-rollup-Binary im macOS-Lock (npm/cli#4828). npm install loest plattformspezifische Optional-Deps frisch auf.