### PR TITLE
fix(ci): rollup-Plattform-Binary (npm/cli#4828)

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,7 +24,12 @@ jobs:
           node-version: '20'
 
       - name: Abhaengigkeiten installieren
-        run: npm install
+        # npm/cli#4828: ein auf anderem OS erzeugter Lock laesst das plattform-
+        # spezifische rollup-Binary fehlen. Lock entfernen erzwingt frische,
+        # plattform-korrekte Aufloesung auf dem Linux-Runner.
+        run: |
+          rm -f package-lock.json
+          npm install --no-audit --no-fund
 
       - name: ESLint
         run: npm run lint


### PR DESCRIPTION
Lock vor npm install entfernen → frische Linux-Aufloesung mit korrektem rollup-Binary.