### PR TITLE
fix(ui): Status einheitlich "Kündigungsfrist endet" (#216)

### DIFF
--- a/src/components/ContractListItem.vue
+++ b/src/components/ContractListItem.vue
@@ -215,7 +215,7 @@ export default {
 				return { cls: 'expired', label: t('contractmanager', 'Abgelaufen'), title: t('contractmanager', 'Das Enddatum ist überschritten.') }
 			}
 			if (this.endingSoon) {
-				return { cls: 'soon', label: t('contractmanager', 'Kündigung fällig'), title: t('contractmanager', 'Die Kündigungsfrist läuft in Kürze ab.') }
+				return { cls: 'soon', label: t('contractmanager', 'Kündigungsfrist endet'), title: t('contractmanager', 'Die Kündigungsfrist läuft in Kürze ab.') }
 			}
 			if (this.contract.status === 'cancelled') {
 				return { cls: 'cancelled', label: t('contractmanager', 'Gekündigt'), title: '' }

--- a/src/views/ContractList.vue
+++ b/src/views/ContractList.vue
@@ -63,7 +63,7 @@
 			</div>
 			<div class="kpi" :class="{ 'kpi--warn': kpiEndingSoon > 0 }">
 				<div class="kpi__lab">
-					<BellRingIcon :size="15" /> {{ t('contractmanager', 'Kündigung fällig') }}
+					<BellRingIcon :size="15" /> {{ t('contractmanager', 'Kündigungsfrist endet') }}
 				</div>
 				<div class="kpi__num">
 					{{ kpiEndingSoon }}


### PR DESCRIPTION
## Problem (#216)

Der Status hieß in der Liste **„Kündigung fällig"**. Der Nutzer wünscht die frühere, treffendere Bezeichnung **„Kündigungsfrist endet"** zurück.

## Ursache

Drei Stellen, zwei Begriffe:
- Status-Chip (`ContractListItem.vue`) → „Kündigung fällig"
- KPI-Card (`ContractList.vue`) → „Kündigung fällig"
- Filter-Option (`ContractList.vue`) → bereits „Kündigungsfrist endet"

## Fix

Chip + KPI durchgängig auf **„Kündigungsfrist endet"** — konsistent mit dem Filter und der vom Nutzer gewünschten Bezeichnung. Reine String-Änderung, keine Logik betroffen.

## Test

- `npm test` → 58/58 grün
- `eslint` → sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)