### PR TITLE
fix(kosten): auto_renewal in Monatskosten + Näherungs-Kennzeichnung (#215)

### DIFF
--- a/src/views/ContractList.vue
+++ b/src/views/ContractList.vue
@@ -207,7 +207,6 @@ import CashMultipleIcon from 'vue-material-design-icons/CashMultiple.vue'
 import BellRingIcon from 'vue-material-design-icons/BellRing.vue'
 import ContractListItem from '../components/ContractListItem.vue'
 import { calculateCancellationDeadline, getEffectiveEndDate } from '../utils/periodUtils.js'
-import { parseLocalDate } from '../utils/dateUtils.js'
 import { DEFAULT_REMINDER_DAYS_1, isEndingSoon } from '../utils/contractStatus'
 import ContractForm from '../components/ContractForm.vue'
 import SettingsService from '../services/SettingsService'
@@ -370,10 +369,14 @@ export default {
 				if (c.status === 'ended' || c.status === 'archived') return false
 				if (!COST_INTERVAL_DIVISOR[c.costInterval]) return false
 				if (!Number.isFinite(parseFloat(c.cost))) return false
-				const effectiveEnd = c.cancelledTo || c.endDate
-				if (effectiveEnd) {
-					const end = parseLocalDate(effectiveEnd)
-					if (end && end < today) return false
+				// Use the EFFECTIVE end date: getEffectiveEndDate rolls auto_renewal
+				// contracts forward and respects cancelledTo. The old code used the
+				// raw endDate, which silently dropped renewing contracts entered with
+				// a past original end date from the cost sum (#215).
+				const end = getEffectiveEndDate(c.endDate, c.contractType, c.renewalPeriod, { status: c.status, cancelledTo: c.cancelledTo })
+				if (end) {
+					end.setHours(0, 0, 0, 0)
+					if (end < today) return false
 				}
 				return true
 			})
@@ -399,10 +402,13 @@ export default {
 			return hasNetto && hasBrutto
 		},
 		kpiMonthlyLabel() {
-			return new Intl.NumberFormat('de-DE', { style: 'currency', currency: this.kpiLeadCurrency }).format(this.kpiMonthlyTotal)
+			// "ca." signals deliberately that this is a rough monthly estimate, not
+			// a cent-exact figure (netto/brutto mixing, part-month expiry, etc. — #215).
+			const formatted = new Intl.NumberFormat('de-DE', { style: 'currency', currency: this.kpiLeadCurrency }).format(this.kpiMonthlyTotal)
+			return t('contractmanager', 'ca. {amount}', { amount: formatted })
 		},
 		kpiMonthlySub() {
-			const parts = [t('contractmanager', 'Laufende Verträge, auf den Monat')]
+			const parts = [t('contractmanager', 'Grobe Orientierung · laufende Verträge auf den Monat')]
 			if (this.kpiAmountTypeMixed) {
 				parts.push(t('contractmanager', 'netto und brutto gemischt'))
 			}


### PR DESCRIPTION
## Kontext (#215)

Zwei Nutzer stolperten über die **„Monatliche Kosten"**-KPI: einer fand die Summe zu hoch und unerklärlich, ein anderer zu niedrig (auto_renewal-Verträge fehlten).

## Änderungen

**1. Bug — auto_renewal-Verträge fielen aus der Summe**
Der Kostenfilter (`kpiCostContracts`) verwendete das **rohe** `endDate`. Verträge mit automatischer Verlängerung, die mit ihrem ursprünglichen (abgelaufenen) Enddatum eingetragen sind, wurden dadurch als „abgelaufen" behandelt und aus der Summe geworfen — obwohl die Liste das hochgerollte Enddatum korrekt anzeigt. Jetzt via `getEffectiveEndDate()` (rollt auto_renewal vor, respektiert `cancelledTo`).

**2. Transparenz — Zahl als Näherung kennzeichnen**
Die Summe ist eine bewusst grobe Monatsrate (netto/brutto gemischt, Versicherungssteuer, unterm Monat auslaufende Verträge). Statt einer trügerisch-genauen Zahl:
- Wert mit **„ca."** (`ca. 1.234,00 €`)
- Untertitel **„Grobe Orientierung · laufende Verträge auf den Monat"**

Bewusst **keine** ausführliche Rechenaufstellung — die würde falsche Genauigkeit vortäuschen.

## Test

- `npm test` → 58/58 grün
- `npm run typecheck` → grün
- `eslint` → sauber (ungenutzter `parseLocalDate`-Import entfernt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)