### PR TITLE
feat(kündigung): "Gekündigt zum" automatisch vorbelegen (#213)

### DIFF
--- a/src/components/ContractForm.vue
+++ b/src/components/ContractForm.vue
@@ -550,7 +550,7 @@ import { getCurrentUser } from '@nextcloud/auth'
 import { generateUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 import { formatDate, formatDateForInput, parseLocalDate } from '../utils/dateUtils.js'
-import { parsePeriod, calculateCancellationDeadline } from '../utils/periodUtils.js'
+import { parsePeriod, calculateCancellationDeadline, getEffectiveEndDate } from '../utils/periodUtils.js'
 import { isUrl, isInternalUrl, getDisplayName } from '../utils/documentUtils.js'
 import { linkifyText } from '../utils/linkify.js'
 import { reminderEnabledForEndDate } from '../utils/reminderForm'
@@ -1028,6 +1028,20 @@ export default {
 				// Cancellation removed — revert auto-set status back to active
 				if (this.form.contractStatus === 'cancelled') {
 					this.form.contractStatus = 'active'
+				}
+				return
+			}
+			// Prefill "Gekündigt zum" with the contract's effective end date so the
+			// user doesn't have to type it twice — it already follows from the
+			// contract data. Only when empty, so a deliberately entered date (e.g.
+			// a special termination) is never overwritten. Stays editable. (#213)
+			if (!this.form.cancelledTo) {
+				const renewalPeriod = this.form.renewalPeriodValue && this.form.renewalPeriodUnit
+					? `${this.form.renewalPeriodValue} ${this.form.renewalPeriodUnit}`
+					: null
+				const effectiveEnd = getEffectiveEndDate(this.form.endDate, this.form.contractType, renewalPeriod)
+				if (effectiveEnd) {
+					this.form.cancelledTo = effectiveEnd
 				}
 			}
 		},


### PR DESCRIPTION
## Wunsch (#213)

Beim Kündigen trägt man „Gekündigt am" ein — und soll „Gekündigt zum" (= Enddatum) nicht noch einmal von Hand eingeben müssen, da es sich aus den Vertragsdaten ergibt. Es soll trotzdem änderbar bleiben.

## Umsetzung

In `onCancelledOnInput` (ContractForm): Sobald „Gekündigt am" gesetzt wird, füllt sich „Gekündigt zum" mit dem **effektiven Enddatum** (`getEffectiveEndDate`):
- fixed → Enddatum
- auto_renewal → nächstes Laufzeitende in der Zukunft

**Nur wenn das Feld leer ist** — eine bewusst eingetragene Sonderkündigung wird nie überschrieben. Das Feld bleibt frei editierbar. Beim Löschen von „Gekündigt am" wird „Gekündigt zum" wie bisher zurückgesetzt.

## Nebeneffekt (positiv)

Bei auto_renewal-Verträgen wird die Kündigung dadurch korrekt zum **nächsten Laufzeitende** wirksam. Vorher (leeres `cancelledTo`) zog der Archivierungs-Job das rohe, teils lange vergangene `endDate` heran — der Vertrag hätte sofort als fällig gelten können.

## Test

- `npm test` → 58/58 grün
- `npm run typecheck` → grün
- `eslint` → sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)