### PR TITLE
ci(review): statisch reviewen — keine Test-/Build-/Install-Versuche

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -110,6 +110,13 @@ jobs:
             Gebaute Artefakte (js/, css/, dist/, vendor/, Lockfiles, signature.json)
             NICHT reviewen — sie sind generiert.
 
+            Fuehre KEINE Tests, Builds oder Installationen aus — composer/npm
+            install sind hier geblockt, vendor/ und node_modules existieren im
+            Checkout nicht, und Tests laufen in eigenen CI-Jobs (phpunit-Matrix,
+            node). Verifiziere Aenderungen ausschliesslich statisch (Diff und
+            Code lesen). Ist ein Befehl geblockt ("requires approval"), probiere
+            KEINE Alternativen — arbeite direkt statisch weiter.
+
             ## Schritt 1: Review
             Reviewe den KOMPLETTEN PR-Diff und pruefe:
             - Code-Qualitaet und Best Practices


### PR DESCRIPTION
Dritter \`error_max_turns\`-Fehlermodus, aufgetreten nach der gestrigen Härtung (rechnungswerk Run 29041325280, PR #98): Die Diff-Beschaffung funktioniert jetzt — aber der Reviewer verbrannte seine 50 Turns mit Versuchen, die **PHPUnit-Tests des PRs auszuführen** (`composer install` / `composer --version` sind geblockt, `vendor/` existiert im Review-Checkout nicht) und probierte hartnäckig Alternativen („verify manually with plain PHP" …), bis das Turn-Budget weg war.

Fix: Prompt-Anweisung, ausschließlich **statisch** zu verifizieren — Tests/Builds laufen in eigenen CI-Jobs (phpunit-Matrix, node); bei geblockten Befehlen keine Alternativen probieren, sondern direkt statisch weiterarbeiten.

Wie gestern paarweise auf develop UND main (Workflow-Validierung gegen Default-Branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q3PjNkw9a7RULdSWZy4nZ