### PR TITLE
chore: package.json-Version auf 1.2.5 angleichen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "contractmanager",
-    "version": "1.2.1",
+    "version": "1.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "contractmanager",
-            "version": "1.2.1",
+            "version": "1.2.5",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "contractmanager",
-    "version": "1.2.1",
+    "version": "1.2.5",
     "description": "Nextcloud App zur Vertragsverwaltung mit Kündigungserinnerungen",
     "main": "src/main.ts",
     "scripts": {


### PR DESCRIPTION
Kosmetische Angleichung: `package.json` und `package-lock.json` standen noch auf `1.2.1`, während die maßgebliche App-Version (`appinfo/info.xml`) längst weiter ist. Jetzt auf `1.2.5` gezogen.

Nur die zwei App-eigenen Versionsfelder geändert (Root + Root-Package im Lock) — Dependency-Versionen unberührt. Kein Funktionsbezug.

Vom Release-Bot-Review zu v1.2.5 als vorbestehende Inkonsistenz angemerkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)