### PR TITLE
feat(migration): Export/Import der Vertragsdaten via user_migration (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Nextcloud App zur Vertragsverwaltung mit automatischen Kündigungserinnerungen.
 - Kategorisierung von Verträgen
 - Archiv für beendete Verträge
 - Integration mit Nextcloud Files für Anhänge
+- Export/Import der eigenen Vertragsdaten über Nextcloud [user_migration](https://github.com/nextcloud/user_migration)
+
+## Datenexport und -import
+
+Die Vertragsdaten eines Nutzers (inklusive Kategorien sowie Kündigungs- und
+Erinnerungseinstellungen) lassen sich über den Standard-Mechanismus von Nextcloud
+exportieren und wieder importieren – „Persönliche Einstellungen → Daten migrieren"
+bzw. `occ user:export` / `occ user:import`. Dokument-Anhänge sind als Pfad-Referenzen
+hinterlegt und werden vom Standard-Datei-Migrator mitgenommen.
+
+**Voraussetzung:** Die offizielle App
+[user_migration](https://github.com/nextcloud/user_migration) muss installiert sein.
+Ohne sie ist der Migrator zwar registriert, wird aber nicht ausgelöst.
 
 ## Anforderungen
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",
-        "nextcloud/ocp": "^32.0 || ^33.0 || ^34.0"
+        "nextcloud/ocp": "^32.0 || ^33.0 || ^34.0",
+        "symfony/console": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -1,6 +1,7 @@
 OC.L10N.register(
     "contractmanager",
     {
+    "Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen" : "Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen",
     "Zuständig" : "Zuständig",
     "Kündigen zum" : "Kündigen zum",
     "Tagesgenau" : "Tagesgenau",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -1,5 +1,6 @@
 {
 	"translations": {
+		"Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen": "Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen",
 		"Zuständig": "Zuständig",
 		"Kündigen zum": "Kündigen zum",
 		"Tagesgenau": "Tagesgenau",

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -1,6 +1,7 @@
 OC.L10N.register(
     "contractmanager",
     {
+    "Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen" : "Your contracts including categories, cancellation and reminder settings",
     "Zuständig" : "Responsible",
     "Kündigen zum" : "Cancel to",
     "Tagesgenau" : "To the day",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -1,5 +1,6 @@
 {
 	"translations": {
+		"Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen": "Your contracts including categories, cancellation and reminder settings",
 		"Zuständig": "Responsible",
 		"Kündigen zum": "Cancel to",
 		"Tagesgenau": "To the day",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\ContractManager\AppInfo;
 
 use OCA\ContractManager\Search\ContractSearchProvider;
+use OCA\ContractManager\UserMigration\ContractMigrator;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -25,6 +26,7 @@ class Application extends App implements IBootstrap {
 
     public function register(IRegistrationContext $context): void {
         $context->registerSearchProvider(ContractSearchProvider::class);
+        $context->registerUserMigrator(ContractMigrator::class);
     }
 
     public function boot(IBootContext $context): void {

--- a/lib/Db/Contract.php
+++ b/lib/Db/Contract.php
@@ -200,8 +200,11 @@ class Contract extends Entity implements JsonSerializable {
      */
     public function markAllFieldsUpdated(): void {
         foreach (array_keys(get_object_vars($this)) as $field) {
-            // Skip Entity's internal bookkeeping (_updatedFields, _fieldTypes).
-            if (str_starts_with($field, '_')) {
+            // Skip Entity's internal bookkeeping (_updatedFields, _fieldTypes)
+            // and the primary key: marking "id" dirty makes QBMapper::insert()
+            // emit an explicit "id = NULL", which fails the NOT NULL/default
+            // sequence constraint on PostgreSQL instead of auto-assigning.
+            if (str_starts_with($field, '_') || $field === 'id') {
                 continue;
             }
             $this->markFieldUpdated($field);

--- a/lib/Db/Contract.php
+++ b/lib/Db/Contract.php
@@ -187,6 +187,27 @@ class Contract extends Entity implements JsonSerializable {
         return $this->deletedAt !== null;
     }
 
+    /**
+     * Force every column to be written on the next insert().
+     *
+     * Entity::setter short-circuits when a value equals the current one
+     * ($args[0] === $this->$name), so a field left at its PHP default is not
+     * marked dirty and QBMapper::insert would omit it, falling back to the DB
+     * column default. For user-migration import we persist a fully-populated
+     * entity wholesale and want the exact imported values (including nulls in
+     * columns that have a non-null DB default, e.g. currency), so we mark all
+     * data fields dirty explicitly.
+     */
+    public function markAllFieldsUpdated(): void {
+        foreach (array_keys(get_object_vars($this)) as $field) {
+            // Skip Entity's internal bookkeeping (_updatedFields, _fieldTypes).
+            if (str_starts_with($field, '_')) {
+                continue;
+            }
+            $this->markFieldUpdated($field);
+        }
+    }
+
     public function jsonSerialize(): array {
         return [
             'id' => $this->id,

--- a/lib/Db/ContractMapper.php
+++ b/lib/Db/ContractMapper.php
@@ -193,6 +193,25 @@ class ContractMapper extends QBMapper {
     }
 
     /**
+     * All contracts strictly OWNED by the user (created_by), active and
+     * archived, excluding trash. Unlike findAllVisible() this does NOT return
+     * other users' non-private contracts — used for user-migration export so
+     * that only the user's own data leaves their account.
+     *
+     * @return Contract[]
+     */
+    public function findAllByOwner(string $userId): array {
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('created_by', $qb->createNamedParameter($userId)))
+            ->andWhere($qb->expr()->isNull('deleted_at'))
+            ->orderBy('id', 'ASC');
+
+        return $this->findEntities($qb);
+    }
+
+    /**
      * @throws DoesNotExistException
      * @throws MultipleObjectsReturnedException
      */

--- a/lib/UserMigration/ContractMigrator.php
+++ b/lib/UserMigration/ContractMigrator.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\UserMigration;
+
+use OCA\ContractManager\AppInfo\Application;
+use OCA\ContractManager\Db\Category;
+use OCA\ContractManager\Db\CategoryMapper;
+use OCA\ContractManager\Db\Contract;
+use OCA\ContractManager\Db\ContractMapper;
+use OCA\ContractManager\Db\ReminderOptOutMapper;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\IMigrator;
+use OCP\UserMigration\TMigratorBasicVersionHandling;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Exports and imports a user's own contract data through the standard Nextcloud
+ * user_migration flow ("Personal settings > Data migration" / occ user:export|import).
+ *
+ * Only data OWNED by the exporting user is included (created_by). Attachments are
+ * kept as path references only — the actual files travel with the standard files
+ * migrator. Categories are a global/shared resource and are deduplicated by name
+ * on import.
+ */
+class ContractMigrator implements IMigrator {
+
+	use TMigratorBasicVersionHandling;
+
+	private const PATH_CONTRACTS = Application::APP_ID . '/contracts.json';
+
+	public function __construct(
+		private ContractMapper $contractMapper,
+		private CategoryMapper $categoryMapper,
+		private ReminderOptOutMapper $optOutMapper,
+		private IAppManager $appManager,
+		private ITimeFactory $timeFactory,
+		private IL10N $l10n,
+	) {
+	}
+
+	public function getId(): string {
+		return Application::APP_ID;
+	}
+
+	public function getDisplayName(): string {
+		return $this->l10n->t('Verträge');
+	}
+
+	public function getDescription(): string {
+		return $this->l10n->t('Deine Verträge samt Kategorien sowie Kündigungs- und Erinnerungseinstellungen');
+	}
+
+	public function export(IUser $user, IExportDestination $exportDestination, OutputInterface $output): void {
+		$output->writeln('Exporting contracts…');
+		$uid = $user->getUID();
+
+		$contracts = $this->contractMapper->findAllByOwner($uid);
+
+		// Collect referenced categories once (deduplicated by id).
+		$categories = [];
+		foreach ($contracts as $contract) {
+			$categoryId = $contract->getCategoryId();
+			if ($categoryId === null || isset($categories[$categoryId])) {
+				continue;
+			}
+			try {
+				$category = $this->categoryMapper->find($categoryId);
+				$categories[$categoryId] = [
+					'exportId' => $category->getId(),
+					'name' => $category->getName(),
+					'sortOrder' => $category->getSortOrder(),
+				];
+			} catch (DoesNotExistException) {
+				// Orphaned reference — contract keeps a null category on import.
+			}
+		}
+
+		$contractsData = [];
+		$optouts = [];
+		foreach ($contracts as $contract) {
+			$categoryId = $contract->getCategoryId();
+			$hasCategory = $categoryId !== null && isset($categories[$categoryId]);
+			$contractsData[] = [
+				'exportId' => $contract->getId(),
+				'categoryExportId' => $hasCategory ? $categoryId : null,
+				'name' => $contract->getName(),
+				'vendor' => $contract->getVendor(),
+				'status' => $contract->getStatus(),
+				'startDate' => $this->dateToString($contract->getStartDate()),
+				'endDate' => $this->dateToString($contract->getEndDate()),
+				'cancelledOn' => $this->dateToString($contract->getCancelledOn()),
+				'cancelledTo' => $this->dateToString($contract->getCancelledTo()),
+				'cancellationPeriod' => $contract->getCancellationPeriod(),
+				'contractType' => $contract->getContractType(),
+				'renewalPeriod' => $contract->getRenewalPeriod(),
+				'cancellationDeadlineType' => $contract->getCancellationDeadlineType(),
+				'cost' => $contract->getCost(),
+				'currency' => $contract->getCurrency(),
+				'costInterval' => $contract->getCostInterval(),
+				'amountType' => $contract->getAmountType(),
+				'contractFolder' => $contract->getContractFolder(),
+				'mainDocument' => $contract->getMainDocument(),
+				'reminderEnabled' => $contract->getReminderEnabled(),
+				'reminderDays' => $contract->getReminderDays(),
+				'notes' => $contract->getNotes(),
+				'customField1' => $contract->getCustomField1(),
+				'customField2' => $contract->getCustomField2(),
+				'customField3' => $contract->getCustomField3(),
+				'archived' => $contract->getArchived(),
+				'isPrivate' => $contract->getIsPrivate(),
+				'responsibleUser' => $contract->getResponsibleUser(),
+				'createdAt' => $this->dateToString($contract->getCreatedAt()),
+				'updatedAt' => $this->dateToString($contract->getUpdatedAt()),
+			];
+			if ($this->optOutMapper->isOptedOut($contract->getId(), $uid)) {
+				$optouts[] = ['contractExportId' => $contract->getId()];
+			}
+		}
+
+		$document = [
+			'schemaVersion' => $this->version,
+			'exportedAt' => $this->timeFactory->getDateTime()->format('c'),
+			'appVersion' => $this->appManager->getAppVersion(Application::APP_ID),
+			'categories' => array_values($categories),
+			'contracts' => $contractsData,
+			'optouts' => $optouts,
+		];
+
+		$exportDestination->addFileContents(
+			self::PATH_CONTRACTS,
+			json_encode($document, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+		);
+		$output->writeln('Exported ' . count($contractsData) . ' contract(s).');
+	}
+
+	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
+		if ($importSource->getMigratorVersion($this->getId()) === null) {
+			$output->writeln('No contracts to import, skipping…');
+			return;
+		}
+		if (!$importSource->pathExists(self::PATH_CONTRACTS)) {
+			return;
+		}
+
+		$uid = $user->getUID();
+		$data = json_decode($importSource->getFileContents(self::PATH_CONTRACTS), true);
+		if (!is_array($data)) {
+			$output->writeln('contracts.json is not readable, skipping…');
+			return;
+		}
+
+		// Categories: deduplicate against the global list by name.
+		$categoryMap = [];
+		foreach ($data['categories'] ?? [] as $categoryData) {
+			$name = (string)($categoryData['name'] ?? '');
+			if ($name === '') {
+				continue;
+			}
+			$existing = $this->categoryMapper->findByName($name);
+			if ($existing !== null) {
+				$categoryMap[$categoryData['exportId']] = $existing->getId();
+				continue;
+			}
+			$category = new Category();
+			$category->setName($name);
+			$category->setSortOrder($this->categoryMapper->getMaxSortOrder() + 1);
+			$inserted = $this->categoryMapper->insert($category);
+			$categoryMap[$categoryData['exportId']] = $inserted->getId();
+		}
+
+		// Contracts: fresh rows owned by the importing user, remapped category.
+		$contractMap = [];
+		foreach ($data['contracts'] ?? [] as $c) {
+			$contract = new Contract();
+			$contract->setName((string)($c['name'] ?? ''));
+			$contract->setVendor((string)($c['vendor'] ?? ''));
+			$contract->setStatus((string)($c['status'] ?? Contract::STATUS_ACTIVE));
+			$categoryExportId = $c['categoryExportId'] ?? null;
+			$contract->setCategoryId($categoryExportId !== null ? ($categoryMap[$categoryExportId] ?? null) : null);
+			$contract->setStartDate($this->stringToDate($c['startDate'] ?? null));
+			$contract->setEndDate($this->stringToDate($c['endDate'] ?? null));
+			$contract->setCancelledOn($this->stringToDate($c['cancelledOn'] ?? null));
+			$contract->setCancelledTo($this->stringToDate($c['cancelledTo'] ?? null));
+			// cancellation_period is NOT NULL without a DB default.
+			$contract->setCancellationPeriod((string)($c['cancellationPeriod'] ?? ''));
+			$contract->setContractType((string)($c['contractType'] ?? Contract::TYPE_FIXED));
+			$contract->setRenewalPeriod($c['renewalPeriod'] ?? null);
+			$contract->setCancellationDeadlineType((string)($c['cancellationDeadlineType'] ?? Contract::DEADLINE_TYPE_NORMAL));
+			$contract->setCost($c['cost'] ?? null);
+			$contract->setCurrency($c['currency'] ?? null);
+			$contract->setCostInterval($c['costInterval'] ?? null);
+			$contract->setAmountType((string)($c['amountType'] ?? Contract::AMOUNT_TYPE_NETTO));
+			$contract->setContractFolder($c['contractFolder'] ?? null);
+			$contract->setMainDocument($c['mainDocument'] ?? null);
+			$contract->setReminderEnabled((int)($c['reminderEnabled'] ?? 1));
+			$contract->setReminderDays(isset($c['reminderDays']) && $c['reminderDays'] !== null ? (int)$c['reminderDays'] : null);
+			$contract->setNotes($c['notes'] ?? null);
+			$contract->setCustomField1($c['customField1'] ?? null);
+			$contract->setCustomField2($c['customField2'] ?? null);
+			$contract->setCustomField3($c['customField3'] ?? null);
+			$contract->setArchived((int)($c['archived'] ?? 0));
+			$contract->setIsPrivate((int)($c['isPrivate'] ?? 0));
+			$contract->setResponsibleUser($c['responsibleUser'] ?? null);
+			$contract->setCreatedAt($this->stringToDate($c['createdAt'] ?? null) ?? $this->timeFactory->getDateTime());
+			$contract->setUpdatedAt($this->stringToDate($c['updatedAt'] ?? null) ?? $this->timeFactory->getDateTime());
+			$contract->setCreatedBy($uid);
+			$contract->markAllFieldsUpdated();
+
+			$inserted = $this->contractMapper->insert($contract);
+			$contractMap[$c['exportId']] = $inserted->getId();
+		}
+
+		// Opt-outs: remap contract id, owned by the importing user.
+		foreach ($data['optouts'] ?? [] as $optout) {
+			$newId = $contractMap[$optout['contractExportId']] ?? null;
+			if ($newId !== null) {
+				$this->optOutMapper->setOptOut($newId, $uid, true);
+			}
+		}
+
+		$output->writeln('Imported ' . count($contractMap) . ' contract(s).');
+	}
+
+	private function dateToString(?\DateTime $date): ?string {
+		return $date?->format('c');
+	}
+
+	private function stringToDate(?string $value): ?\DateTime {
+		if ($value === null || $value === '') {
+			return null;
+		}
+		return new \DateTime($value);
+	}
+}

--- a/tests/Unit/UserMigration/ContractMigratorTest.php
+++ b/tests/Unit/UserMigration/ContractMigratorTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\UserMigration;
+
+use OCA\ContractManager\Db\Category;
+use OCA\ContractManager\Db\CategoryMapper;
+use OCA\ContractManager\Db\Contract;
+use OCA\ContractManager\Db\ContractMapper;
+use OCA\ContractManager\Db\ReminderOptOutMapper;
+use OCA\ContractManager\UserMigration\ContractMigrator;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+class ContractMigratorTest extends TestCase {
+
+	private ContractMapper $contractMapper;
+	private CategoryMapper $categoryMapper;
+	private ReminderOptOutMapper $optOutMapper;
+	private IAppManager $appManager;
+	private ITimeFactory $timeFactory;
+	private ContractMigrator $migrator;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->contractMapper = $this->createMock(ContractMapper::class);
+		$this->categoryMapper = $this->createMock(CategoryMapper::class);
+		$this->optOutMapper = $this->createMock(ReminderOptOutMapper::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime('2026-07-24T12:00:00+00:00'));
+		$this->appManager->method('getAppVersion')->willReturn('1.2.6');
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$this->migrator = new ContractMigrator(
+			$this->contractMapper,
+			$this->categoryMapper,
+			$this->optOutMapper,
+			$this->appManager,
+			$this->timeFactory,
+			$l10n,
+		);
+	}
+
+	private function user(string $uid): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	private function makeContract(int $id, string $name, ?int $categoryId, string $createdBy): Contract {
+		$c = new Contract();
+		$c->setId($id);
+		$c->setName($name);
+		$c->setVendor('ACME');
+		$c->setStatus(Contract::STATUS_ACTIVE);
+		$c->setCategoryId($categoryId);
+		$c->setStartDate(new \DateTime('2026-01-01'));
+		$c->setEndDate(new \DateTime('2026-12-31'));
+		$c->setCancellationPeriod('3 Monate');
+		$c->setContractType(Contract::TYPE_FIXED);
+		$c->setCreatedBy($createdBy);
+		$c->setCreatedAt(new \DateTime('2026-01-01T10:00:00+00:00'));
+		$c->setUpdatedAt(new \DateTime('2026-01-02T10:00:00+00:00'));
+		return $c;
+	}
+
+	public function testExportProducesExpectedDocument(): void {
+		$c1 = $this->makeContract(11, 'Strom', 5, 'alice');
+		$c2 = $this->makeContract(12, 'Handy', null, 'alice');
+
+		$this->contractMapper->method('findAllByOwner')->with('alice')->willReturn([$c1, $c2]);
+
+		$category = new Category();
+		$category->setId(5);
+		$category->setName('Versicherung');
+		$category->setSortOrder(2);
+		$this->categoryMapper->method('find')->with(5)->willReturn($category);
+
+		// c1 opted out, c2 not.
+		$this->optOutMapper->method('isOptedOut')->willReturnCallback(
+			fn (int $cid, string $uid) => $cid === 11 && $uid === 'alice',
+		);
+
+		$captured = null;
+		$dest = $this->createMock(IExportDestination::class);
+		$dest->expects($this->once())
+			->method('addFileContents')
+			->with('contractmanager/contracts.json', $this->callback(function (string $content) use (&$captured) {
+				$captured = $content;
+				return true;
+			}));
+
+		$this->migrator->export($this->user('alice'), $dest, new NullOutput());
+
+		$doc = json_decode($captured, true);
+		$this->assertSame(1, $doc['schemaVersion']);
+		$this->assertSame('1.2.6', $doc['appVersion']);
+		$this->assertCount(1, $doc['categories']);
+		$this->assertSame(5, $doc['categories'][0]['exportId']);
+		$this->assertSame('Versicherung', $doc['categories'][0]['name']);
+		$this->assertCount(2, $doc['contracts']);
+		$this->assertSame(11, $doc['contracts'][0]['exportId']);
+		$this->assertSame(5, $doc['contracts'][0]['categoryExportId']);
+		$this->assertNull($doc['contracts'][1]['categoryExportId']);
+		$this->assertSame('Strom', $doc['contracts'][0]['name']);
+		// Only c1 opted out.
+		$this->assertCount(1, $doc['optouts']);
+		$this->assertSame(11, $doc['optouts'][0]['contractExportId']);
+	}
+
+	public function testImportCreatesContractsWithRemappedCategoryAndOwner(): void {
+		$json = json_encode([
+			'schemaVersion' => 1,
+			'categories' => [
+				['exportId' => 5, 'name' => 'Versicherung', 'sortOrder' => 2],
+			],
+			'contracts' => [
+				[
+					'exportId' => 11, 'categoryExportId' => 5, 'name' => 'Strom', 'vendor' => 'ACME',
+					'status' => 'active', 'startDate' => '2026-01-01T00:00:00+00:00',
+					'endDate' => '2026-12-31T00:00:00+00:00', 'cancellationPeriod' => '3 Monate',
+					'contractType' => 'fixed', 'reminderEnabled' => 1, 'archived' => 0, 'isPrivate' => 0,
+					'createdAt' => '2026-01-01T10:00:00+00:00', 'updatedAt' => '2026-01-02T10:00:00+00:00',
+				],
+			],
+			'optouts' => [
+				['contractExportId' => 11],
+			],
+		]);
+
+		$source = $this->createMock(IImportSource::class);
+		$source->method('getMigratorVersion')->with('contractmanager')->willReturn(1);
+		$source->method('pathExists')->with('contractmanager/contracts.json')->willReturn(true);
+		$source->method('getFileContents')->with('contractmanager/contracts.json')->willReturn($json);
+
+		// New category (not present yet) → insert, gets id 99.
+		$this->categoryMapper->method('findByName')->with('Versicherung')->willReturn(null);
+		$this->categoryMapper->method('getMaxSortOrder')->willReturn(7);
+		$this->categoryMapper->method('insert')->willReturnCallback(function (Category $cat) {
+			$cat->setId(99);
+			return $cat;
+		});
+
+		$insertedContracts = [];
+		$this->contractMapper->method('insert')->willReturnCallback(function (Contract $c) use (&$insertedContracts) {
+			$c->setId(1000 + count($insertedContracts));
+			$insertedContracts[] = $c;
+			return $c;
+		});
+
+		$optOutCalls = [];
+		$this->optOutMapper->method('setOptOut')->willReturnCallback(
+			function (int $cid, string $uid, bool $v) use (&$optOutCalls): void {
+				$optOutCalls[] = [$cid, $uid, $v];
+			},
+		);
+
+		$this->migrator->import($this->user('bob'), $source, new NullOutput());
+
+		$this->assertCount(1, $insertedContracts);
+		$contract = $insertedContracts[0];
+		$this->assertSame('Strom', $contract->getName());
+		$this->assertSame(99, $contract->getCategoryId(), 'category id must be remapped to the newly inserted one');
+		$this->assertSame('bob', $contract->getCreatedBy(), 'owner must become the importing user');
+		$this->assertSame('3 Monate', $contract->getCancellationPeriod());
+		// Opt-out remapped to the new contract id and owned by bob.
+		$this->assertSame([[1000, 'bob', true]], $optOutCalls);
+	}
+
+	public function testImportDeduplicatesCategoryByName(): void {
+		$json = json_encode([
+			'schemaVersion' => 1,
+			'categories' => [
+				['exportId' => 5, 'name' => 'Versicherung', 'sortOrder' => 2],
+			],
+			'contracts' => [
+				[
+					'exportId' => 11, 'categoryExportId' => 5, 'name' => 'Strom', 'vendor' => 'ACME',
+					'status' => 'active', 'startDate' => '2026-01-01T00:00:00+00:00',
+					'endDate' => '2026-12-31T00:00:00+00:00', 'cancellationPeriod' => '3 Monate',
+					'contractType' => 'fixed', 'reminderEnabled' => 1, 'archived' => 0, 'isPrivate' => 0,
+				],
+			],
+			'optouts' => [],
+		]);
+
+		$source = $this->createMock(IImportSource::class);
+		$source->method('getMigratorVersion')->willReturn(1);
+		$source->method('pathExists')->willReturn(true);
+		$source->method('getFileContents')->willReturn($json);
+
+		// Category with that name already exists globally → reuse id 7, no insert.
+		$existing = new Category();
+		$existing->setId(7);
+		$existing->setName('Versicherung');
+		$this->categoryMapper->method('findByName')->with('Versicherung')->willReturn($existing);
+		$this->categoryMapper->expects($this->never())->method('insert');
+
+		$insertedContracts = [];
+		$this->contractMapper->method('insert')->willReturnCallback(function (Contract $c) use (&$insertedContracts) {
+			$c->setId(2000);
+			$insertedContracts[] = $c;
+			return $c;
+		});
+
+		$this->migrator->import($this->user('carol'), $source, new NullOutput());
+
+		$this->assertCount(1, $insertedContracts);
+		$this->assertSame(7, $insertedContracts[0]->getCategoryId(), 'must reuse the existing category id');
+	}
+
+	public function testImportSkipsWhenMigratorVersionMissing(): void {
+		$source = $this->createMock(IImportSource::class);
+		$source->method('getMigratorVersion')->willReturn(null);
+		$this->contractMapper->expects($this->never())->method('insert');
+
+		$this->migrator->import($this->user('dave'), $source, new NullOutput());
+	}
+}


### PR DESCRIPTION
## Kontext

Externes Feedback zu #273 (myssv, Markoise) hat den Fokus vom reinen Export zum
**Roundtrip** verschoben: Nutzer wollen die Daten auch wieder **importieren**.
Markoise nannte konkret die offizielle App
[user_migration](https://github.com/nextcloud/user_migration) als Traeger.

Design: `docs/design-273-export-import.md`, Plan: `docs/plan.md` (beide lokal, docs/ ist gitignored).

## Umsetzung

Ein `ContractMigrator implements IMigrator` (OCP, stabil seit NC 24), registriert per
einer Zeile in `Application::register()`. Export und Import laufen ueber den
Standard-Flow von Nextcloud. Kein Frontend, kein Endpoint, keine DB-Migration.

### Entscheidungen mit Begruendung

- **Owner-strikte Query (`ContractMapper::findAllByOwner`)**: `findAllVisible` liefert
  auch *fremde nicht-private* Vertraege (`is_private=0 OR created_by=uid OR responsible_user=uid`).
  Fuer einen Account-Export waere das falsch — es wuerde fremde Daten mitziehen und beim
  Import duplizieren. Papierkorb bleibt aussen vor, archivierte Vertraege sind dabei.
- **Kategorien per Name dedupliziert**: Kategorien sind **instanzweit geteilt**
  (keine User-Spalte, keine Owner-Filterung im Mapper). Schlichtes "Anhaengen" wuerde die
  geteilte Liste der Zielinstanz mit Dubletten zumuellen.
- **`Contract::markAllFieldsUpdated()`**: `Entity::setter` macht `if ($args[0] === $this->$name) return;`
  und markiert ein Feld nicht dirty, wenn der Wert dem PHP-Default entspricht;
  `QBMapper::insert` schreibt nur `getUpdatedFields()`. Ohne das Erzwingen faellt der
  Import auf DB-Spalten-Defaults zurueck statt die exportierten Werte zu schreiben
  (z. B. ein bewusst leeres `currency`).
- **`reminder_sent` nicht exportiert** — transientes Versandlog.
- **Datei-Anhaenge** bleiben Pfad-Referenzen (`contract_folder`, `main_document`);
  die Dateien nimmt der Standard-Files-Migrator ohnehin mit.

## Tests

4 neue PHPUnit-Faelle (Export-Dokument, Import mit Remapping, Kategorie-Dedupe,
Skip ohne Migrator-Version). Gesamte Unit-Suite: **144 Tests gruen**.

## Smoke-Test (lokal, NC 34 + user_migration 10.4.0)

- `occ user:export --list=full` zeigt den Migrator korrekt als *Contracts* / `contractmanager`
  mit lokalisierter Beschreibung.
- `occ user:export --types=contractmanager admin` → **7 von 11** Vertraegen exportiert
  (die 4 im Papierkorb korrekt ausgelassen), `migrator_versions.json` enthaelt `"contractmanager":1`.
- `occ user:import --user=<anderer User>` → 7 Vertraege angelegt, `created_by` = Zielnutzer,
  `category_id` korrekt remappt, **keine einzige Kategorie dupliziert** (weiterhin genau 5),
  alle Werte originalgetreu inkl. Dezimalkosten und Umlauten.
- Testdaten und Wegwerf-Nutzer anschliessend restlos entfernt, Instanz im Ausgangszustand.

## Hinweise

- `symfony/console` als `require-dev` ergaenzt: der `OutputInterface`-Typehint der
  IMigrator-Signatur wird im Unit-Test gebraucht. Nicht im Release (`--no-dev`).
- Voraussetzung auf Nutzerseite ist die installierte user_migration-App. Ohne sie ist der
  Migrator zwar registriert, wird aber nicht ausgeloest — in der README dokumentiert.
- Das periodische App-eigene Auto-Backup aus dem urspruenglichen Issue-Text ist nach
  #296 herausgeloest.

Fixes #273