### PR TITLE
ci(review): Claude-Review fuer Dependabot-PRs ueberspringen (main-Sync)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,22 @@ on:
 
 jobs:
   claude-review:
-    # Only review non-draft PRs
-    if: github.event.pull_request.draft == false
+    # Nur nicht-Draft-PRs reviewen.
+    #
+    # Dependabot-PRs ausgenommen (19.07.2026): GitHub reicht regulaere
+    # Actions-Secrets bei dependabot-getriggerten Laeufen bewusst NICHT durch —
+    # Dependabot-PRs werden von Inhalten fremder Pakete beeinflusst. Das Review
+    # scheiterte dort deshalb dauerhaft an einem leeren
+    # CLAUDE_CODE_OAUTH_TOKEN. Das Token als Dependabot-Secret zu hinterlegen
+    # waere moeglich, wuerde aber genau diese Schutzmassnahme aushebeln — fuer
+    # einen Nutzen nahe null, weil ein Versionsbump in package-lock.json nichts
+    # hergibt, was die Test-Jobs nicht schon abdecken. Die laufen weiter.
+    #
+    # Bewusst ueber user.login statt github.actor: bei einem Rerun waere actor
+    # der Mensch, der neu gestartet hat, nicht der PR-Autor.
+    if: |
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -91,8 +105,11 @@ jobs:
           # Auth: OAuth Token bevorzugt (claude_code_oauth_token).
           # Alternative: anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Erlaubt Claude Bot als Trigger (wenn claude.yml PRs erstellt/pusht)
-          allowed_bots: "claude[bot],github-actions[bot]"
+          # Erlaubt Claude Bot als Trigger (wenn claude.yml PRs erstellt/pusht).
+          # dependabot[bot] bleibt gelistet, obwohl der Job fuer Dependabot-PRs
+          # oben gar nicht mehr startet: schadet nicht und haelt fest, dass der
+          # Fall geprueft wurde (siehe Job-Kommentar).
+          allowed_bots: "claude[bot],github-actions[bot],dependabot[bot]"
           show_full_output: true
           prompt: |
             Du bist ein Code-Reviewer.
@@ -167,7 +184,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "claude[bot],github-actions[bot]"
+          allowed_bots: "claude[bot],github-actions[bot],dependabot[bot]"
           show_full_output: true
           prompt: |
             Du bist ein RELEASE-Reviewer für einen Nextcloud-App-Release-PR.
@@ -228,3 +245,35 @@ jobs:
         run: |
           echo "::error::Claude-Review wurde still uebersprungen (Workflow-Validierung gegen main). Workflow-Datei develop/main synchronisieren und Run neu starten."
           exit 1
+
+      - name: Hinweis am PR wenn das Review fehlgeschlagen ist
+        # Ein abgebrochener Review-Job hinterlaesst am PR sonst NICHTS: kein
+        # Kommentar, und wer nur auf die Bot-Kommentare schaut, haelt den PR
+        # faelschlich fuer ungeprueft-aber-unauffaellig. Am 16.07.2026 blieb so
+        # der Dependabot-PR #482 drei Tage ohne Review liegen, ohne dass es
+        # jemandem auffiel. Dieser Schritt macht die Luecke am PR sichtbar.
+        # Laeuft NICHT bei cancelled() — der Race-Guard oben bricht bewusst ab.
+        # NO_REVIEW enthaelt bewusst weder APPROVED noch NEEDS_FIX, damit der
+        # Zyklus-Zaehler oben davon unberuehrt bleibt.
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=$(cat <<EOF
+          ### Claude Code Review — fehlgeschlagen
+
+          Der Review-Lauf ist abgebrochen, es liegt **kein Review-Ergebnis** fuer diesen Stand vor.
+          Dieser PR gilt damit als **ungeprueft** — nicht mergen, ohne das aufzuloesen.
+
+          [Zum fehlgeschlagenen Run](${RUN_URL})
+
+          Naechste Schritte:
+          - Run neu starten (gh run rerun RUN-ID --failed)
+          - Bleibt es dabei: Workflow-Datei zwischen develop und main abgleichen, die Action validiert gegen den Default-Branch
+
+          **Status: NO_REVIEW**
+          EOF
+          )
+          gh pr comment "${PR_NUMBER}" --body "${BODY}"


### PR DESCRIPTION
Main-Sync des gleichnamigen develop-PRs. Inhaltlich identische Datei.

Die claude-code-action validiert die Workflow-Datei gegen den Default-Branch.
Bleibt main auf dem alten Stand, wird das Review auf allen kuenftigen PRs still
uebersprungen. Deshalb muss diese Aenderung paarweise auf develop UND main.

Begruendung siehe develop-PR.