### PR TITLE
fix(users): Verträge eines gelöschten Nutzers an Nachfolger übergeben (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Wird ein Nutzerkonto gelöscht, verlieren dessen Verträge nicht mehr stillschweigend ihren Eigentümer: Die Zuständigkeit geht an einen Nachfolger über, der per `occ config:app:set contractmanager deletion_successor --value=<Nutzer>` festgelegt wird. Ohne festgelegten Nachfolger bleibt alles unverändert. Verträge werden dabei nie gelöscht, auch nicht die im Papierkorb, und der Ersteller bleibt als Angabe erhalten. Verträge mit einem anderen Verantwortlichen sowie private Verträge bleiben unberührt (#299)
+- Verträge im Papierkorb werden nicht mehr automatisch nach 30 Tagen endgültig gelöscht, wenn ihr Ersteller kein Konto mehr hat. Endgültig löschen kann sie damit nur noch ein Administrator (#299)
+
 ## [1.2.6] - 2026-07-23
 
 ### Added

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace OCA\ContractManager\AppInfo;
 
+use OCA\ContractManager\Listener\UserDeletedListener;
 use OCA\ContractManager\Search\ContractSearchProvider;
 use OCA\ContractManager\UserMigration\ContractMigrator;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserDeletedEvent;
 
 class Application extends App implements IBootstrap {
     public const APP_ID = 'contractmanager';
@@ -27,6 +29,7 @@ class Application extends App implements IBootstrap {
     public function register(IRegistrationContext $context): void {
         $context->registerSearchProvider(ContractSearchProvider::class);
         $context->registerUserMigrator(ContractMigrator::class);
+        $context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
     }
 
     public function boot(IBootContext $context): void {

--- a/lib/BackgroundJob/TrashCleanupJob.php
+++ b/lib/BackgroundJob/TrashCleanupJob.php
@@ -10,6 +10,7 @@ use OCA\ContractManager\Db\ContractMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -18,15 +19,21 @@ use Psr\Log\LoggerInterface;
  * - Runs daily
  * - Deletes contracts that have been in trash for more than 30 days
  * - Excludes contracts created by admin users (their trash is never auto-cleaned)
+ * - Excludes contracts whose creator no longer has an account (#299): purging
+ *   those for good stays a deliberate admin action
  */
 class TrashCleanupJob extends TimedJob {
 
 	private const TRASH_RETENTION_DAYS = 30;
 
+	/** @var array<string, bool> */
+	private array $userExistsCache = [];
+
 	public function __construct(
 		ITimeFactory $time,
 		private ContractMapper $contractMapper,
 		private IGroupManager $groupManager,
+		private IUserManager $userManager,
 		private LoggerInterface $logger,
 	) {
 		parent::__construct($time);
@@ -71,7 +78,17 @@ class TrashCleanupJob extends TimedJob {
 		$expiredContracts = $this->contractMapper->findExpiredDeleted($cutoffDate, $adminUserIds);
 
 		$deletedCount = 0;
+		$orphanedCount = 0;
 		foreach ($expiredContracts as $contract) {
+			// Contracts whose creator no longer has an account are left alone
+			// (#299): once the owner is gone, nobody can restore them anymore,
+			// so purging them silently would take the decision away from the
+			// admin. Deleting these for good stays a deliberate admin action.
+			if (!$this->userStillExists($contract->getCreatedBy())) {
+				$orphanedCount++;
+				continue;
+			}
+
 			try {
 				$this->contractMapper->delete($contract);
 				$deletedCount++;
@@ -92,7 +109,32 @@ class TrashCleanupJob extends TimedJob {
 			}
 		}
 
+		if ($orphanedCount > 0) {
+			$this->logger->info('Kept trashed contracts of deleted users from auto-cleanup', [
+				'app' => Application::APP_ID,
+				'keptCount' => $orphanedCount,
+			]);
+		}
+
 		return $deletedCount;
+	}
+
+	/**
+	 * Whether the given user id still resolves to an account.
+	 *
+	 * Cached per run: a single user can easily own many expired contracts, and
+	 * this cannot be decided in SQL.
+	 */
+	private function userStillExists(string $userId): bool {
+		if ($userId === '') {
+			return false;
+		}
+
+		if (!array_key_exists($userId, $this->userExistsCache)) {
+			$this->userExistsCache[$userId] = $this->userManager->userExists($userId);
+		}
+
+		return $this->userExistsCache[$userId];
 	}
 
 	/**

--- a/lib/Db/ContractMapper.php
+++ b/lib/Db/ContractMapper.php
@@ -435,4 +435,31 @@ class ContractMapper extends QBMapper {
             ->andWhere($this->effectiveOwnerExpr($qb, $from));
         return $qb->executeStatement();
     }
+
+    /**
+     * Reassign responsibility after the owner's account was deleted (#299).
+     *
+     * Differs from reassignResponsible() in one point: private contracts are
+     * left alone. The user marked them private on purpose, and handing them to
+     * another non-admin would reverse that decision after the fact. They stay
+     * put and remain visible to admins, who decide what happens to them.
+     *
+     * Trash rows are excluded as well, but for a different reason: the trash
+     * view filters on createdBy, not on responsibleUser, so reassigning them
+     * would have no visible effect at all. They are instead kept from being
+     * auto-purged by TrashCleanupJob.
+     *
+     * createdBy is never touched - it documents who created the contract.
+     *
+     * @return int Number of contracts updated
+     */
+    public function reassignOnOwnerDeletion(string $from, string $to): int {
+        $qb = $this->db->getQueryBuilder();
+        $qb->update($this->getTableName())
+            ->set('responsible_user', $qb->createNamedParameter($to))
+            ->where($qb->expr()->isNull('deleted_at'))
+            ->andWhere($qb->expr()->eq('is_private', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+            ->andWhere($this->effectiveOwnerExpr($qb, $from));
+        return $qb->executeStatement();
+    }
 }

--- a/lib/Db/ReminderOptOutMapper.php
+++ b/lib/Db/ReminderOptOutMapper.php
@@ -85,4 +85,24 @@ class ReminderOptOutMapper extends QBMapper {
 			->where($qb->expr()->eq('contract_id', $qb->createNamedParameter($contractId, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
 	}
+
+	/**
+	 * Delete all opt-outs of a user (used when their account is deleted, #299).
+	 *
+	 * An opt-out is a setting, not a record of something that happened: it has
+	 * no timestamp and only means "do not remind me about this contract".
+	 * Nextcloud drops the app's other per-user settings along with the account;
+	 * this one only survives because it lives in the app's own table instead of
+	 * oc_preferences. Leaving it behind matters because Nextcloud allows a uid
+	 * to be handed out again, and a stale row would silently mute reminders for
+	 * whoever gets that uid next.
+	 *
+	 * @return int Number of rows removed
+	 */
+	public function deleteByUser(string $userId): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
+		return $qb->executeStatement();
+	}
 }

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Listener;
+
+use OCA\ContractManager\AppInfo\Application;
+use OCA\ContractManager\Db\ContractMapper;
+use OCA\ContractManager\Db\ReminderOptOutMapper;
+use OCA\ContractManager\Service\SettingsService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserManager;
+use OCP\User\Events\UserDeletedEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Keeps contract data usable when a Nextcloud account is deleted (#299).
+ *
+ * Guiding rule: nothing that documents a business event is removed. Contracts
+ * are company data, and createdBy records who set a contract up - that stays,
+ * account or no account. What the listener does is hand responsibility to a
+ * configured successor so the contracts do not silently lose their owner.
+ *
+ * Deliberately NOT done here:
+ * - deleting contracts, including the ones in the trash (see TrashCleanupJob,
+ *   which keeps them from being auto-purged once their creator is gone)
+ * - touching contractmgr_reminders, a dated delivery log and therefore a record
+ * - handing over private contracts, which stay for an admin to decide on
+ * - nulling responsibleUser: createdBy carries the stale uid anyway, so it
+ *   would only drop information
+ *
+ * @template-implements IEventListener<UserDeletedEvent>
+ */
+class UserDeletedListener implements IEventListener {
+
+	public function __construct(
+		private ContractMapper $contractMapper,
+		private ReminderOptOutMapper $optOutMapper,
+		private SettingsService $settingsService,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof UserDeletedEvent)) {
+			return;
+		}
+
+		$uid = $event->getUser()->getUID();
+
+		// Account deletion must never fail because of this app. Anything that
+		// goes wrong here is logged and swallowed.
+		try {
+			$removedOptOuts = $this->optOutMapper->deleteByUser($uid);
+
+			$successor = $this->resolveSuccessor($uid);
+			$reassigned = $successor === null
+				? 0
+				: $this->contractMapper->reassignOnOwnerDeletion($uid, $successor);
+
+			$this->logger->info('Handled contract data of deleted user', [
+				'app' => Application::APP_ID,
+				'uid' => $uid,
+				'successor' => $successor,
+				'reassignedContracts' => $reassigned,
+				'removedOptOuts' => $removedOptOuts,
+			]);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to handle contract data of deleted user: ' . $e->getMessage(), [
+				'app' => Application::APP_ID,
+				'uid' => $uid,
+				'exception' => $e,
+			]);
+		}
+	}
+
+	/**
+	 * The configured successor, or null when no handover should happen.
+	 *
+	 * Empty is the default and means contracts are left as they are - the
+	 * conservative choice for instances that never configured this.
+	 */
+	private function resolveSuccessor(string $deletedUid): ?string {
+		$successor = $this->settingsService->getDeletionSuccessor();
+
+		if ($successor === '' || $successor === $deletedUid) {
+			return null;
+		}
+
+		if (!$this->userManager->userExists($successor)) {
+			$this->logger->warning('Configured successor does not exist, contracts left unassigned', [
+				'app' => Application::APP_ID,
+				'successor' => $successor,
+			]);
+			return null;
+		}
+
+		return $successor;
+	}
+}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -35,6 +35,8 @@ class SettingsService {
 
 	private const KEY_CUSTOM_FIELD_LABEL_PREFIX = 'custom_field_label_';
 
+	private const KEY_DELETION_SUCCESSOR = 'deletion_successor';
+
 	private const KEY_AI_PROVIDER = 'ai_provider';
 	private const KEY_AI_API_KEY = 'ai_api_key';
 	private const KEY_AI_API_URL = 'ai_api_url';
@@ -147,6 +149,29 @@ class SettingsService {
 	// ========================================
 	// Custom Field Labels (Admin)
 	// ========================================
+
+	/**
+	 * Get the user contracts are handed over to when their owner's account is
+	 * deleted (#299). Empty means no automatic handover happens.
+	 */
+	public function getDeletionSuccessor(): string {
+		return $this->config->getAppValue(
+			Application::APP_ID,
+			self::KEY_DELETION_SUCCESSOR,
+			''
+		);
+	}
+
+	/**
+	 * Set the successor for contracts of deleted users. Empty clears it.
+	 */
+	public function setDeletionSuccessor(string $userId): void {
+		$this->config->setAppValue(
+			Application::APP_ID,
+			self::KEY_DELETION_SUCCESSOR,
+			trim($userId)
+		);
+	}
 
 	/**
 	 * Get label for a custom field (1-3)

--- a/tests/Unit/BackgroundJob/TrashCleanupJobTest.php
+++ b/tests/Unit/BackgroundJob/TrashCleanupJobTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\BackgroundJob;
+
+use OCA\ContractManager\BackgroundJob\TrashCleanupJob;
+use OCA\ContractManager\Db\Contract;
+use OCA\ContractManager\Db\ContractMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * #299: trashed contracts of a deleted user must survive the automatic
+ * retention cleanup. Once the owner is gone nobody can restore them, so
+ * deleting them for good stays a deliberate admin action.
+ */
+class TrashCleanupJobTest extends TestCase {
+
+	private ContractMapper $contractMapper;
+	private IUserManager $userManager;
+	private TrashCleanupJob $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$time = $this->createMock(ITimeFactory::class);
+		$this->contractMapper = $this->createMock(ContractMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('get')->willReturn(null);
+
+		$this->job = new TrashCleanupJob(
+			$time,
+			$this->contractMapper,
+			$groupManager,
+			$this->userManager,
+			$logger
+		);
+	}
+
+	private function invokeRun(): void {
+		(new \ReflectionMethod($this->job, 'run'))->invoke($this->job, null);
+	}
+
+	private function contractOf(string $createdBy): Contract {
+		$contract = new Contract();
+		$contract->setName('Vertrag von ' . $createdBy);
+		$contract->setCreatedBy($createdBy);
+		return $contract;
+	}
+
+	public function testExpiredContractOfExistingUserIsDeleted(): void {
+		$contract = $this->contractOf('alice');
+
+		$this->contractMapper->method('findExpiredDeleted')->willReturn([$contract]);
+		$this->userManager->method('userExists')->with('alice')->willReturn(true);
+
+		$this->contractMapper->expects($this->once())
+			->method('delete')
+			->with($contract);
+
+		$this->invokeRun();
+	}
+
+	public function testExpiredContractOfDeletedUserIsKept(): void {
+		$contract = $this->contractOf('ghost');
+
+		$this->contractMapper->method('findExpiredDeleted')->willReturn([$contract]);
+		$this->userManager->method('userExists')->with('ghost')->willReturn(false);
+
+		$this->contractMapper->expects($this->never())->method('delete');
+
+		$this->invokeRun();
+	}
+
+	public function testExistenceIsCheckedOncePerUser(): void {
+		$contracts = [
+			$this->contractOf('alice'),
+			$this->contractOf('alice'),
+			$this->contractOf('bob'),
+		];
+
+		$this->contractMapper->method('findExpiredDeleted')->willReturn($contracts);
+
+		$this->userManager->expects($this->exactly(2))
+			->method('userExists')
+			->willReturn(true);
+
+		$this->invokeRun();
+	}
+
+	public function testMixedBatchDeletesOnlyContractsOfExistingUsers(): void {
+		$alive = $this->contractOf('alice');
+		$orphan = $this->contractOf('ghost');
+
+		$this->contractMapper->method('findExpiredDeleted')->willReturn([$alive, $orphan]);
+		$this->userManager->method('userExists')->willReturnMap([
+			['alice', true],
+			['ghost', false],
+		]);
+
+		$this->contractMapper->expects($this->once())
+			->method('delete')
+			->with($alive);
+
+		$this->invokeRun();
+	}
+}

--- a/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ContractManager\Tests\Unit\Listener;
+
+use OCA\ContractManager\Db\ContractMapper;
+use OCA\ContractManager\Db\ReminderOptOutMapper;
+use OCA\ContractManager\Listener\UserDeletedListener;
+use OCA\ContractManager\Service\SettingsService;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\User\Events\UserDeletedEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * #299: when an account is deleted, its contracts must not lose their owner
+ * silently. Nothing that documents a business event is removed here.
+ */
+class UserDeletedListenerTest extends TestCase {
+
+	private ContractMapper $contractMapper;
+	private ReminderOptOutMapper $optOutMapper;
+	private SettingsService $settingsService;
+	private IUserManager $userManager;
+	private UserDeletedListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->contractMapper = $this->createMock(ContractMapper::class);
+		$this->optOutMapper = $this->createMock(ReminderOptOutMapper::class);
+		$this->settingsService = $this->createMock(SettingsService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new UserDeletedListener(
+			$this->contractMapper,
+			$this->optOutMapper,
+			$this->settingsService,
+			$this->userManager,
+			$logger
+		);
+	}
+
+	private function deletionOf(string $uid): UserDeletedEvent {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return new UserDeletedEvent($user);
+	}
+
+	public function testOptOutsOfDeletedUserAreRemoved(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('');
+
+		$this->optOutMapper->expects($this->once())
+			->method('deleteByUser')
+			->with('alice')
+			->willReturn(2);
+
+		$this->listener->handle($this->deletionOf('alice'));
+	}
+
+	public function testNoSuccessorConfiguredLeavesContractsAlone(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('');
+
+		$this->contractMapper->expects($this->never())->method('reassignOnOwnerDeletion');
+
+		$this->listener->handle($this->deletionOf('alice'));
+	}
+
+	public function testContractsAreHandedToConfiguredSuccessor(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('bob');
+		$this->userManager->method('userExists')->with('bob')->willReturn(true);
+
+		$this->contractMapper->expects($this->once())
+			->method('reassignOnOwnerDeletion')
+			->with('alice', 'bob')
+			->willReturn(3);
+
+		$this->listener->handle($this->deletionOf('alice'));
+	}
+
+	public function testSuccessorWithoutAccountIsIgnored(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('ghost');
+		$this->userManager->method('userExists')->with('ghost')->willReturn(false);
+
+		$this->contractMapper->expects($this->never())->method('reassignOnOwnerDeletion');
+
+		$this->listener->handle($this->deletionOf('alice'));
+	}
+
+	/**
+	 * Guards against configuring the very user that is being deleted, which
+	 * would hand the contracts to an account that no longer exists.
+	 */
+	public function testSuccessorEqualToDeletedUserIsIgnored(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('alice');
+
+		$this->contractMapper->expects($this->never())->method('reassignOnOwnerDeletion');
+
+		$this->listener->handle($this->deletionOf('alice'));
+	}
+
+	/**
+	 * Deleting an account must never fail because of this app.
+	 */
+	public function testFailingMapperDoesNotBreakUserDeletion(): void {
+		$this->settingsService->method('getDeletionSuccessor')->willReturn('bob');
+		$this->userManager->method('userExists')->willReturn(true);
+		$this->contractMapper->method('reassignOnOwnerDeletion')
+			->willThrowException(new \RuntimeException('database gone'));
+
+		$this->listener->handle($this->deletionOf('alice'));
+
+		$this->addToAssertionCount(1);
+	}
+
+	public function testUnrelatedEventIsIgnored(): void {
+		$this->optOutMapper->expects($this->never())->method('deleteByUser');
+
+		$this->listener->handle(new Event());
+	}
+}


### PR DESCRIPTION
PR 1 von 2 zu #299. Grundlage: `docs/design-299-user-deletion.md`, `docs/plan-299-pr1.md`.

## Ausgangslage

Die App registrierte keinen Listener auf die Kontolöschung. Verträge eines gelöschten Nutzers blieben mit einer toten uid zurück und verloren ihren Eigentümer, ohne dass es jemandem auffiel.

Die Design-Phase hat zwei Annahmen aus dem Issue widerlegt:

1. **Die Daten sind nicht unsichtbar.** `ContractMapper::findAllVisible()` setzt für Admins keinen Sichtbarkeitsfilter, Nicht-Admins sehen zusätzlich alles mit `is_private = 0`. Was nach einer Kontolöschung verschwindet, sind nur private Verträge und nur für Nicht-Admins.
2. **Das DSGVO-Argument trägt nicht.** Vertragsdaten sind Geschäftsdaten, und wer einen Vertrag angelegt hat, dokumentiert einen Vorgang im Unternehmen. Das Ausscheiden eines Mitarbeiters ist kein Grund, diese Dokumentation zu entfernen.

Aus #299 wird damit kein Löschthema, sondern ein Nachfolge- und Sichtbarkeitsthema.

## Was dieser PR tut

**Neuer `UserDeletedListener`** (`OCP\User\Events\UserDeletedEvent`, registriert in `Application::register()`):

- hängt die Zuständigkeit auf einen konfigurierten Nachfolger um
- entfernt die Opt-out-Zeilen des gelöschten Nutzers
- läuft vollständig in `try/catch (\Throwable)`, damit die Kontolöschung nie an dieser App scheitert
- arbeitet nur mit Bulk-Statements, weil er synchron in `occ user:delete` läuft

Die Regel beim Umhängen nutzt den vorhandenen `effectiveOwnerExpr()`, der die Fallunterscheidung bereits abbildet:

| Fall | Aktion |
|------|--------|
| Vertrag hat einen anderen lebenden Verantwortlichen | unverändert |
| nicht privat, kein anderer Verantwortlicher, Nachfolger gesetzt | geht an den Nachfolger |
| privat, oder kein Nachfolger konfiguriert | unverändert, bleibt für den Admin sichtbar |

**`TrashCleanupJob`** überspringt Verträge, deren Ersteller kein Konto mehr hat. Nach dem Verschwinden des Eigentümers kann sie niemand mehr wiederherstellen, endgültiges Löschen bleibt damit eine bewusste Admin-Entscheidung. Existenzprüfungen sind pro Lauf und uid gecacht, weil sie sich nicht in SQL entscheiden lassen.

**`deletion_successor`** als App-Wert, Default leer. Leer bedeutet: keine automatische Übertragung, die konservative Voreinstellung für bestehende Instanzen. Gesetzt wird er vorerst per `occ config:app:set contractmanager deletion_successor --value=<uid>`; das Eingabefeld kommt in PR 2.

## Bewusst nicht angetastet

- **`created_by`** bleibt in jedem Fall erhalten. Es dokumentiert, wer den Vertrag angelegt hat.
- **`contractmgr_reminders`** bleibt erhalten. Ein datiertes Versandprotokoll ist nach derselben Logik Dokumentation.
- **`responsible_user`** wird nicht auf NULL gesetzt, entgegen dem Vorschlag im Issue: `created_by` trägt die uid ohnehin weiter, NULL würde nur Information löschen.
- **Papierkorb-Zeilen** werden nicht umgehängt. `findDeletedByUser()` filtert über `created_by`, nicht über `responsible_user`, ein Umhängen hätte also keine sichtbare Wirkung. Sie werden stattdessen vor der Auto-Löschung geschützt.
- **Die Sichtbarkeitsregel** wird nicht angefasst. Dass `created_by` allein Zugriff gewährt, ist als Befund an #95 dokumentiert und gehört zum Berechtigungskonzept.

Einzige Löschung im ganzen PR sind die Opt-out-Zeilen. Ein Opt-out ist eine Einstellung ohne Zeitstempel, kein Vorgang, und Nextcloud entfernt die übrigen Einstellungen eines Nutzers ohnehin mit dem Konto. Relevant ist das, weil Nextcloud eine uid neu vergeben kann: `Manager::createUserFromBackend` prüft nur, ob aktuell jemand mit dieser uid existiert. Eine liegengebliebene Zeile würde den nächsten Inhaber dieser uid still von Erinnerungen ausschließen.

## Tests

155 PHPUnit-Tests grün, davon 11 neue (vorher 144). PHP-Lint aller geänderten Dateien grün.

- `UserDeletedListenerTest`: Opt-outs entfernt, kein Nachfolger konfiguriert, gültiger Nachfolger, Nachfolger ohne Konto, Nachfolger gleich dem gelöschten Nutzer, Mapper wirft Exception, fremdes Event
- `TrashCleanupJobTest`: Ersteller existiert, Ersteller gelöscht, gemischter Stapel, Existenzprüfung höchstens einmal pro uid

## Smoke-Test

Lokale NC 34 (pgsql), fünf Verträge als Ausgangslage, beide Pfade durchgespielt.

**Ohne konfigurierten Nachfolger:** kein Vertrag angefasst, `created_by` überall erhalten, Versandprotokoll erhalten. Entfernt wurde ausschließlich die Opt-out-Zeile des gelöschten Nutzers, die eines anderen Nutzers auf demselben Vertrag blieb als Kontrolle liegen.

**Mit Nachfolger:** Der nicht-private Vertrag ohne Verantwortlichen ging an den Nachfolger. Unverändert blieben der Vertrag mit anderem Verantwortlichen, der private Vertrag, die Papierkorb-Zeile und der Vertrag eines fremden Nutzers. Log-Eintrag:

```
"message":"Handled contract data of deleted user",
"data":{"app":"contractmanager","uid":"cm-leaver","successor":"cm-successor",
        "reassignedContracts":"1","removedOptOuts":"1"}
```

**Papierkorb:** `TrashCleanupJob` manuell ausgeführt. Der Kontrollvertrag eines existierenden Nicht-Admins mit abgelaufener Frist wurde endgültig gelöscht, die Waise blieb liegen, mit Log-Eintrag als Begründung.

Testdaten, Testnutzer, App-Wert und der temporär gesenkte Loglevel danach restlos entfernt.

## Rollen

Der Rollen-Durchlauf (Admin, Editor, Viewer) betrifft PR 1 nicht: Der Listener läuft im Systemkontext, der Job als Background Job, es gibt keinen Endpunkt und keine UI. Er gehört zu PR 2, wo Filter und Einstellungsfeld dazukommen.

## Folgt in PR 2

Eingabefeld für den Nachfolger, Benachrichtigung an die Admins mit den beiden Zahlen, Filter „Ohne aktiven Eigentümer" zum Sichten und Weiterreichen.
