### PR TITLE
chore(security): App-Store-Token aus techstack.md entfernen

### DIFF
--- a/.claude/techstack.md
+++ b/.claude/techstack.md
@@ -323,12 +323,21 @@ gh release create vX.Y.Z ../contractmanager-vX.Y.Z.tar.gz \
   --title "vX.Y.Z" --notes "Siehe CHANGELOG.md"
 
 # 17. App Store Upload
+# Der Token kommt aus der Umgebungsvariable NC_APPSTORE_TOKEN, hinterlegt in
+# .claude/settings.local.json (gitignored). Vorher pruefen, sonst 401.
+test -n "$NC_APPSTORE_TOKEN" || { echo "FEHLER: NC_APPSTORE_TOKEN nicht gesetzt (siehe .claude/settings.local.json)"; exit 1; }
+
 DOWNLOAD_URL="https://github.com/cpcMomentum/contractmanager/releases/download/vX.Y.Z/contractmanager-vX.Y.Z.tar.gz"
 curl -X POST https://apps.nextcloud.com/api/v1/apps/releases \
-  -H "Authorization: Token d31fa215d4d16f3aefdab27d971f356727cc995a" \
+  -H "Authorization: Token $NC_APPSTORE_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{\"download\": \"$DOWNLOAD_URL\", \"signature\": \"$SIGNATURE\"}"
 ```
+
+**Niemals einen Token-Wert in diese Datei zurueckschreiben** — sie ist im Git
+getrackt und dieses Repo ist oeffentlich. Der frueher hier hartkodierte Token
+war dadurch seit dem 29.04.2026 auf GitHub einsehbar und musste am 04.08.2026
+im App Store neu erzeugt werden.
 
 **Phase 8: Aufraemen**
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ npm-debug.log*
 .env
 .env.local
 
+# Claude Code: lokale Secrets (z.B. NC_APPSTORE_TOKEN), siehe .claude/techstack.md
+.claude/settings.local.json
+
 # Composer
 composer.lock
 


### PR DESCRIPTION
## Problem

Der Nextcloud-App-Store-Token stand seit `d89e772` (29.04.2026) hartkodiert in `.claude/techstack.md` Zeile 328 — beim Ausrollen des Release-Workflows in dieses Repo mitgewandert.

Dieses Repo ist **public**. Der Wert lag auf `main` und `develop` im aktuellen HEAD, war also gut drei Monate öffentlich einsehbar.

## Was gemacht wurde

- Upload liest den Token aus `$NC_APPSTORE_TOKEN` (hinterlegt in `.claude/settings.local.json`, gitignored)
- Guard `test -n "$NC_APPSTORE_TOKEN"` davor, sonst läuft der Upload in ein 401 und man sucht an der falschen Stelle
- Warnhinweis unter dem Block, damit der Wert nicht zurückwandert

Gleiches Muster wie im Infra-Repo, wo dieselbe Stelle am 03.08. bereinigt wurde.

## Was ausserhalb dieses PR passiert ist

- Token am 04.08.2026 im App Store **neu erzeugt** — der alte ist damit wertlos
- Sweep über alle sechs Repos (`git grep` + `find`/`xargs`): keine weitere Kopie, worktime/rechnungswerk/vinarium/brandmail sind sauber

## Bewusst nicht gemacht

Kein History-Rewrite. Der alte Wert bleibt in der Historie, ist aber nach der Rotation tot. Ein `filter-repo` + Force-Push würde alle Commit-Hashes seit April umschreiben, bei über 60 Remote-Branches und offenen Dependabot-PRs.

Ein zweiter PR bringt denselben Stand nach `main` — dort steht der Token ebenfalls noch.

Nur Dokumentation, kein Code, kein Build betroffen.