### PR TITLE
chore(hooks): Secret-Check und Konfliktmarker-Check aus worktime uebernehmen

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,18 +1,104 @@
 #!/usr/bin/env bash
-# Pre-commit hook: Enforce OCP-only API usage in PHP files.
+# Pre-commit hook fuer die App-Flotte.
 #
-# Blocks commits that introduce usage of internal \OC_*, \OC::, \OC\ namespace
-# or "use OC\..." imports. Only OCP\ and OCA\ are public and stable.
-#
-# Rationale: OC_App::getAppPath() was deprecated since NC 11 and removed in
-# NC 33, which caused live user installations to crash on upgrade (worktime#88,
-# contractmanager#86). The OCP-only rule is documented in CLAUDE.md and
-# .claude/dev.md but was previously only enforced manually.
+# Check 1: Merge-Konfliktmarker in gestagten Dateien
+# Check 2: Zugangsschluessel (Secrets)
+# Check 3: OCP-only API usage in PHP-Dateien
 #
 # Override (strongly discouraged): git commit --no-verify
 
 set -euo pipefail
 
+# --- Check 1: Conflict markers in staged files ---
+CONFLICT_STAGED=$(git diff --cached --name-only --diff-filter=ACM || true)
+if [ -n "$CONFLICT_STAGED" ]; then
+    CONFLICT_VIOLATIONS=""
+    for file in $CONFLICT_STAGED; do
+        [ -f "$file" ] || continue
+        MATCHES=$(git show ":$file" | grep -nE '^(<{7,}|={7,}|>{7,})' || true)
+        if [ -n "$MATCHES" ]; then
+            CONFLICT_VIOLATIONS="${CONFLICT_VIOLATIONS}${file}:
+${MATCHES}
+
+"
+        fi
+    done
+
+    if [ -n "$CONFLICT_VIOLATIONS" ]; then
+        printf '\033[0;31m[Conflict-Marker Check] BLOCKED\033[0m\n\n'
+        printf 'Git merge conflict markers detected in staged files.\n'
+        printf '(Siehe worktime: Konfliktmarker in JS brachen das v0.6.2-Release.)\n\n'
+        printf '%s' "$CONFLICT_VIOLATIONS"
+        exit 1
+    fi
+fi
+
+# --- Check 2: Secrets in staged files (worktime#538) ---
+# Anlass: der App-Store-Token stand von 04/2026 bis 08/2026 hartkodiert in
+# contractmanager/.claude/techstack.md — in einem oeffentlichen Repo
+# (contractmanager#308). GitHubs Secret Scanning faengt das NICHT: es gibt kein
+# Nextcloud-Muster, und ein blanker 40-Zeichen-Hex-String ist von einem
+# Commit-Hash nicht zu unterscheiden.
+#
+# Deshalb kontextgebunden statt "40 Hex" allein — sonst schlaegt jeder
+# Commit-Hash in CHANGELOG.md oder composer.lock an.
+#
+# Steht bewusst VOR Check 3: der laeuft nur bei PHP-Dateien und beendet den
+# Hook sonst frueh. Der Leak kam ueber eine .md-Datei.
+SECRET_STAGED=$(git diff --cached --name-only --diff-filter=ACM || true)
+if [ -n "$SECRET_STAGED" ]; then
+    SECRET_VIOLATIONS=""
+    for file in $SECRET_STAGED; do
+        [ -f "$file" ] || continue
+        # appinfo/signature.json ist eine generierte Liste aus Dateipfaden und
+        # SHA-512-Hashes. Pfade wie vendor/doctrine/lexer/src/Token.php neben
+        # einem Hash sehen wie ein Geheimnis aus, sind aber keins — und die
+        # Datei wird bei JEDEM Release neu erzeugt.
+        case "$file" in
+            appinfo/signature.json) continue ;;
+        esac
+        CONTENT=$(git show ":$file" 2>/dev/null || true)
+        [ -n "$CONTENT" ] || continue
+
+        # a) App-Store-Token im Authorization-Header (der belegte Fall)
+        # b) langer Hex-Wert auf einer Zeile, die ihn als Geheimnis ausweist
+        # c) private Schluessel (Signaturzertifikate gehoeren nach ~/.nextcloud/)
+        # Treffer zusammenfuehren und je Zeile nur einmal melden — a und b
+        # greifen beim Leak-Fall beide.
+        M=$( {
+            printf '%s' "$CONTENT" | grep -nE 'Authorization:[[:space:]]*Token[[:space:]]+[0-9a-f]{40}' || true
+            printf '%s' "$CONTENT" | grep -niE '(token|secret|api[_-]?key|passwor[dt])["'"'"']?[[:space:]]*[:=]+[[:space:]]*["'"'"']?[0-9a-f]{32,}' || true
+            printf '%s' "$CONTENT" | grep -nE '^-----BEGIN [A-Z ]*PRIVATE KEY-----' || true
+        } | sort -t: -k1,1n -u || true)
+
+        if [ -n "$M" ]; then
+            SECRET_VIOLATIONS="${SECRET_VIOLATIONS}${file}:
+${M}
+
+"
+        fi
+    done
+
+    if [ -n "$SECRET_VIOLATIONS" ]; then
+        printf '\033[0;31m[Secret Check] BLOCKED\033[0m\n\n'
+        printf 'Moeglicher Zugangsschluessel in einer gestagten Datei.\n\n'
+        printf 'Secrets gehoeren nach .claude/settings.local.json (gitignored),\n'
+        printf 'im Code stattdessen die Variable lesen, z.B. $NC_APPSTORE_TOKEN.\n'
+        printf 'Private Schluessel gehoeren nach ~/.nextcloud/certificates/.\n\n'
+        printf '%s' "$SECRET_VIOLATIONS"
+        printf 'Fehlalarm? Dann Muster in .githooks/pre-commit schaerfen —\n'
+        printf 'nicht den Hook mit --no-verify umgehen.\n'
+        exit 1
+    fi
+fi
+
+# --- Check 3: OCP-only API usage in PHP files ---
+# Blocks commits that introduce usage of internal \OC_*, \OC::, \OC\ namespace
+# or "use OC\..." imports. Only OCP\ and OCA\ are public and stable.
+#
+# Rationale: OC_App::getAppPath() was deprecated since NC 11 and removed in
+# NC 33, which caused live user installations to crash on upgrade (worktime#88,
+# contractmanager#86).
 PATTERN='(^|[^A-Za-z])OC_[A-Z][a-zA-Z_]*::|\\OC::|\\OC\\[A-Z]|^use OC\\[A-Z]|^use OC;'
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$' || true)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -66,7 +66,7 @@ if [ -n "$SECRET_STAGED" ]; then
         # Treffer zusammenfuehren und je Zeile nur einmal melden — a und b
         # greifen beim Leak-Fall beide.
         M=$( {
-            printf '%s' "$CONTENT" | grep -nE 'Authorization:[[:space:]]*Token[[:space:]]+[0-9a-f]{40}' || true
+            printf '%s' "$CONTENT" | grep -niE 'Authorization:[[:space:]]*Token[[:space:]]+[0-9a-f]{40}' || true
             printf '%s' "$CONTENT" | grep -niE '(token|secret|api[_-]?key|passwor[dt])["'"'"']?[[:space:]]*[:=]+[[:space:]]*["'"'"']?[0-9a-f]{32,}' || true
             printf '%s' "$CONTENT" | grep -nE '^-----BEGIN [A-Z ]*PRIVATE KEY-----' || true
         } | sort -t: -k1,1n -u || true)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "test:watch": "vitest",
         "typecheck": "vue-tsc --noEmit",
         "lint": "eslint --ext .js,.ts,.vue src",
-        "lint:fix": "eslint --ext .js,.ts,.vue src --fix"
+        "lint:fix": "eslint --ext .js,.ts,.vue src --fix",
+        "prepare": "git config core.hooksPath .githooks || true"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Rollout von cpcMomentum/worktime#538 (PR worktime#539).

## Warum

Der App-Store-Token stand von April bis August 2026 hartkodiert in `contractmanager/.claude/techstack.md`, in einem öffentlichen Repo (cpcMomentum/contractmanager#308). Nichts hat den Commit aufgehalten.

GitHubs Secret Scanning fängt genau diesen Fall **nicht** — kein Nextcloud-Muster, und ein blanker 40-Zeichen-Hex-String ist von einem Commit-Hash nicht zu unterscheiden. GitGuardian hat ihn gemeldet, aber erst vier Monate später und nur, weil das Repo öffentlich ist.

## Was drin ist

Der Hook bestand hier bislang nur aus dem OCP-Check (44 Zeilen) und war gegenüber worktime zurück. Jetzt einheitlich:

| Check | Inhalt |
|---|---|
| 1 | Merge-Konfliktmarker — brach in worktime das v0.6.2-Release |
| 2 | Secrets, kontextgebunden |
| 3 | OCP-only, unverändert übernommen |

Muster in Check 2:

- `Authorization: Token <40 hex>` — der belegte Fall
- `token`/`secret`/`api_key`/`password` als Zuweisung mit Hex-Wert
- `-----BEGIN ... PRIVATE KEY-----`

Bewusst kontextgebunden statt „40 Hex" allein, sonst schlägt jeder Commit-Hash an.

Check 2 steht **vor** Check 3: der läuft nur bei PHP-Dateien und beendet den Hook sonst früh — der Leak kam über eine `.md`-Datei und wäre dahinter nie gesehen worden.

`appinfo/signature.json` ist ausgenommen: die generierte Hash-Liste enthält Pfade wie `vendor/doctrine/lexer/src/Token.php` neben einem SHA-512 und hätte sonst **jedes Release blockiert**.

**`"prepare": "git config core.hooksPath .githooks"`** in `package.json`: Die Hooks lagen im Repo, aber git aktiviert sie nicht von selbst — in contractmanager war die Konfiguration nie gesetzt, die Hooks liefen dort nie. Ab jetzt erledigt `npm install` das.

## Getestet

- Leak-Fall (`Authorization: Token <hex>`) wird blockiert
- Commit-Hashes im Fließtext laufen durch
- **0 Fehlalarme** über alle getrackten Dateien dieses Repos

Nur Tooling, kein App-Code, kein Build betroffen.

## Bekannt und bewusst offen

Der Hook ist lokal und mit `--no-verify` umgehbar; für externe PR-Beiträge greift er nicht. Ein CI-Gate mit demselben Scan auf den PR-Diff ist als Folge-Issue erfasst.