### PR TITLE
fix(hooks): diff3-Konfliktmarker im Conflict-Check erkennen

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,7 +15,7 @@ if [ -n "$CONFLICT_STAGED" ]; then
     CONFLICT_VIOLATIONS=""
     for file in $CONFLICT_STAGED; do
         [ -f "$file" ] || continue
-        MATCHES=$(git show ":$file" | grep -nE '^(<{7,}|={7,}|>{7,})' || true)
+        MATCHES=$(git show ":$file" | grep -nE '^(<{7,}|={7,}|>{7,}|[|]{7,})' || true)
         if [ -n "$MATCHES" ]; then
             CONFLICT_VIOLATIONS="${CONFLICT_VIOLATIONS}${file}:
 ${MATCHES}


### PR DESCRIPTION
Nachzug zu #311.

Der Review-Bot hat denselben Hook in vinarium#224 geprüft und dort eine Lücke gefunden, die hier ebenfalls besteht: bei `merge.conflictStyle = diff3` schreibt git einen vierten Markertyp `|||||||`, den der Conflict-Check nicht kannte.

Übernahme des Fixes (vinarium `f1acf83`), damit der Hook in allen fünf Repos identisch bleibt.

Verifiziert: eine gestagte Datei mit `||||||| base` wird blockiert.

Nur Tooling, kein App-Code.