### PR TITLE
chore(branding): Anzeigename auf VertragsWerk umstellen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Anzeigename der App auf „VertragsWerk" umgestellt (App-ID bleibt `contractmanager`)
+
 ### Fixed
 - Wird ein Nutzerkonto gelöscht, verlieren dessen Verträge nicht mehr stillschweigend ihren Eigentümer: Die Zuständigkeit geht an einen Nachfolger über, der per `occ config:app:set contractmanager deletion_successor --value=<Nutzer>` festgelegt wird. Ohne festgelegten Nachfolger bleibt alles unverändert. Verträge werden dabei nie gelöscht, auch nicht die im Papierkorb, und der Ersteller bleibt als Angabe erhalten. Verträge mit einem anderen Verantwortlichen sowie private Verträge bleiben unberührt (#299)
 - Verträge im Papierkorb werden nicht mehr automatisch nach 30 Tagen endgültig gelöscht, wenn ihr Ersteller kein Konto mehr hat. Endgültig löschen kann sie damit nur noch ein Administrator (#299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Anzeigename der App auf „VertragsWerk" umgestellt (App-ID bleibt `contractmanager`)
 
 ### Fixed
+- Beträge mit zwei Nachkommastellen bleiben erhalten: „10,50" wurde im Vertragsformular als „10,5" angezeigt und blieb auch nach dem Korrigieren und Speichern so. Das Feld nimmt jetzt auch die deutsche Komma-Schreibweise entgegen und zeigt Beträge einheitlich mit zwei Nachkommastellen (#305)
+- Ein Betrag, der sich nicht als Zahl lesen lässt oder über 99.999.999,99 liegt, wird beim Speichern mit einem Hinweis abgewiesen, statt zu einem Serverfehler zu führen (#315)
+- Das ausgelieferte JavaScript enthielt Entwicklungscode: Die App lädt jetzt ein kleineres Paket und läuft im Browser schneller. Fehlermeldungen der Oberfläche, die nur im Entwicklungsmodus auftraten, sind damit ebenfalls verschwunden (#306)
 - Wird ein Nutzerkonto gelöscht, verlieren dessen Verträge nicht mehr stillschweigend ihren Eigentümer: Die Zuständigkeit geht an einen Nachfolger über, der per `occ config:app:set contractmanager deletion_successor --value=<Nutzer>` festgelegt wird. Ohne festgelegten Nachfolger bleibt alles unverändert. Verträge werden dabei nie gelöscht, auch nicht die im Papierkorb, und der Ersteller bleibt als Angabe erhalten. Verträge mit einem anderen Verantwortlichen sowie private Verträge bleiben unberührt (#299)
 - Verträge im Papierkorb werden nicht mehr automatisch nach 30 Tagen endgültig gelöscht, wenn ihr Ersteller kein Konto mehr hat. Endgültig löschen kann sie damit nur noch ein Administrator (#299)
 
 ### Added
+- Die eigenen Vertragsdaten lassen sich jetzt über Nextclouds App [user_migration](https://github.com/nextcloud/user_migration) mit exportieren und wieder einspielen: `occ user:export` legt sie ins Standard-Archiv, `occ user:import` spielt sie samt Kategorien zurück, ohne die vorhandene Kategorienliste zu verdoppeln. Verträge im Papierkorb bleiben außen vor, angehängte Dateien nimmt Nextcloud selbst mit (#273)
 - Neue Administrator-Einstellung „Nachfolger bei gelöschtem Konto": Wer hier eingetragen ist, übernimmt die Zuständigkeit für die Verträge gelöschter Konten. Ohne Eintrag bleibt alles unverändert (#299)
 - Administratoren werden benachrichtigt, wenn ein Konto gelöscht wurde, samt Anzahl der übertragenen Verträge und derer, die noch eine Zuordnung brauchen (#299)
 - Neuer Filter „Ohne aktiven Eigentümer" in der Vertragsliste, nur für Administratoren: zeigt Verträge, deren Zuständiger beziehungsweise Ersteller kein Konto mehr hat, und macht sie über „Verträge übertragen" weiterreichbar (#299)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# ContractManager
+# VertragsWerk
 
 Nextcloud App zur Vertragsverwaltung mit automatischen Kündigungserinnerungen.
+Die App-ID bleibt `contractmanager`.
 
 ## Features
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,10 +3,10 @@
       xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 
     <id>contractmanager</id>
-    <name>Verträge</name>
+    <name>VertragsWerk</name>
     <summary>Vertragsverwaltung mit Kündigungserinnerungen</summary>
     <description><![CDATA[
-# Verträge
+# VertragsWerk
 
 Verwalten Sie Ihre Verträge zentral in Nextcloud:
 
@@ -57,7 +57,7 @@ Behalten Sie den Überblick über Laufzeiten, Kosten und Kündigungsfristen.
 
     <navigations>
         <navigation>
-            <name>Verträge</name>
+            <name>VertragsWerk</name>
             <route>contractmanager.page.index</route>
             <icon>app.svg</icon>
             <order>10</order>


### PR DESCRIPTION
Fuehrt die App an die Namensfamilie heran (WorkTime, RechnungsWerk). Seit mehreren Sessions vorgemerkt, soll mit 1.2.7 raus.

**Die App-ID bleibt `contractmanager`** — es aendert sich nur der angezeigte Name. Keine Migration, keine Routen, keine Datenbank.

## Geaendert

| Stelle | vorher | nachher |
|---|---|---|
| `info.xml:6` `<name>` | Verträge | VertragsWerk |
| `info.xml:9` Ueberschrift der Store-Beschreibung | # Verträge | # VertragsWerk |
| `info.xml:60` Navigationseintrag | Verträge | VertragsWerk |
| `README.md:1` Titel | ContractManager | VertragsWerk |

Der README-Titel stand bisher auf `ContractManager` und war damit weder der alte noch der neue Anzeigename. Dazu ein Satz, dass die App-ID unveraendert bleibt.

## Bewusst nicht geaendert

**Die In-App-Ueberschrift und der Navigationseintrag innerhalb der App** heissen weiterhin `Verträge` (`src/App.vue:16`, `src/views/ContractList.vue:4`). Das entspricht dem Muster der Schwester-App: RechnungsWerk heisst im Nextcloud-Menue `RechnungsWerk`, ueberschreibt seine Liste aber mit `Rechnungen` (`rechnungswerk/src/views/InvoicesView.vue:4`). Der Produktname steht aussen, der Inhalt innen.

**Stellen, an denen "Verträge" das gewoehnliche Wort ist** und nicht der Name — `info.xml:11`, `info.xml:16`, `README.md:10`, `README.md:11`.

## Fuer den Changelog

Nutzer sehen nach dem Update einen anderen Namen im App-Menue. Das gehoert in die Release Notes und nicht still hinein — die App hat echte Nutzer, die sie unter "Verträge" kennen.

## Geprueft

`xmllint --noout appinfo/info.xml` — wohlgeformt. Keine Aenderung an `src/`, daher kein neues Bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYM3gpdDnxsxDgJv2VgAXe